### PR TITLE
fixed typo in helix-cli create-key help description

### DIFF
--- a/helix-cli/src/args.rs
+++ b/helix-cli/src/args.rs
@@ -60,7 +60,7 @@ pub enum CommandType {
     /// Remove login credentials
     Logout,
 
-    /// Create a new key for a clowd cluster
+    /// Create a new key for a cloud cluster
     #[command(name = "create-key")]
     CreateKey { cluster: String },
 }


### PR DESCRIPTION
## Description
Changed 'clowd' to 'cloud' in the help dialog of 'create-key' in helix-cli

## Related Issues
#343 

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [x] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`
- [x] Lines are kept under 100 characters where possible
- [x] Code is good

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers --> 