### PR TITLE
impr(analyzer): implementing deduping secondary indexes

### DIFF
--- a/helix-db/src/helixc/analyzer/analyzer.rs
+++ b/helix-db/src/helixc/analyzer/analyzer.rs
@@ -5,13 +5,14 @@ use crate::helixc::{
         methods::{
             migration_validation::validate_migration,
             query_validation::validate_query,
-            schema_methods::{build_field_lookups, check_schema, SchemaVersionMap},
+            schema_methods::{SchemaVersionMap, build_field_lookups, check_schema},
         },
         types::Type,
     },
-    generator::{Source as GeneratedSource},
+    generator::Source as GeneratedSource,
     parser::helix_parser::{EdgeSchema, ExpressionType, Field, Query, Source},
 };
+use itertools::Itertools;
 use serde::Serialize;
 use std::{
     borrow::Cow,
@@ -100,6 +101,7 @@ impl<'a> Ctx<'a> {
                             .filter(|f| f.is_indexed())
                             .map(|f| f.name.clone())
                     })
+                    .dedup()
                     .collect(),
             )
             .ok();


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
implementing deduping secondary indexes

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`
- [ ] Lines are kept under 100 characters where possible
- [ ] Code is good

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers --> 