### PR TITLE
Return raw cosine similarity as distance

### DIFF
--- a/helix-db/src/helix_engine/vector_core/vector_distance.rs
+++ b/helix-db/src/helix_engine/vector_core/vector_distance.rs
@@ -8,20 +8,34 @@ pub trait DistanceCalc {
     fn distance(from: &HVector, to: &HVector) -> Result<f64, VectorError>;
 }
 impl DistanceCalc for HVector {
-    /// Calculates the distance between two vectors.
+    /// Return the cosine similarity between two vectors.
+    /// - 1.0 (most similar)
+    /// - 0.0 (orthogonal)
+    /// - -1.0 (most dissimilar)
     ///
-    /// It normalizes the distance to be between 0 and 2.
-    ///
-    /// - 1.0 (most similar) → Distance 0.0 (closest)
-    /// - 0.0 (orthogonal) → Distance 1.0
-    /// - -1.0 (most dissimilar) → Distance 2.0 (furthest)
+    /// Previously, it mapped it to a distance, 0.0 to 2.0. That is now outdated.
     #[inline(always)]
     #[cfg(feature = "cosine")]
     fn distance(from: &HVector, to: &HVector) -> Result<f64, VectorError> {
-        cosine_similarity(&from.data, &to.data).map(|sim| 1.0 - sim)
+        cosine_similarity(&from.data, &to.data)
     }
-}
 
+    // TODO: If we want to instead use the below, brute_force_search_v has to be updated to call this
+    //       instead of cosine_similarity directly.
+    // ///
+    // /// Calculates the distance between two vectors.
+    // ///
+    // /// It normalizes the distance to be between 0 and 2.
+    // ///
+    // /// - 1.0 (most similar) → Distance 0.0 (closest)
+    // /// - 0.0 (orthogonal) → Distance 1.0
+    // /// - -1.0 (most dissimilar) → Distance 2.0 (furthest)
+    // #[inline(always)]
+    // #[cfg(feature = "cosine")]
+    // fn distance(from: &HVector, to: &HVector) -> Result<f64, VectorError> {
+    //     cosine_similarity(&from.data, &to.data).map(|sim| 1.0 - sim)
+    // }
+}
 
 #[inline]
 #[cfg(feature = "cosine")]


### PR DESCRIPTION
## Description
Currently, `search_v` returns a distance, mapped by `1.0 - cosine_similarity`. However, `brute_force_search_v` returns the raw cosine similarity, and that is used by the `SearchV` MCP tool. The docs mention that SearchV returns cosine similarity and so this changes the distance calculation to be a no-op and to return `cosine_similarity`.

## Related Issues

Closes #431 

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers --> 