### PR TITLE
Fix CLI update command

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -40,19 +40,19 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            binary_name: helix-cli-linux-amd64
+            binary_name: helix-x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            binary_name: helix-cli-linux-arm64
+            binary_name: helix-aarch64-unknown-linux-gnu
           - os: macos-13
             target: x86_64-apple-darwin
-            binary_name: helix-cli-macos-amd64
+            binary_name: helix-x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin
-            binary_name: helix-cli-macos-arm64
+            binary_name: helix-aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            binary_name: helix-cli-windows-amd64.exe
+            binary_name: helix-x86_64-pc-windows-msvc.exe
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cliv2.yml
+++ b/.github/workflows/cliv2.yml
@@ -40,19 +40,19 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            binary_name: helix-cli-linux-amd64
+            binary_name: helix-x86_64-unknown-linux-gnu
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            binary_name: helix-cli-linux-arm64
+            binary_name: helix-aarch64-unknown-linux-gnu
           - os: macos-13
             target: x86_64-apple-darwin
-            binary_name: helix-cli-macos-amd64
+            binary_name: helix-x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin
-            binary_name: helix-cli-macos-arm64
+            binary_name: helix-aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            binary_name: helix-cli-windows-amd64.exe
+            binary_name: helix-x86_64-pc-windows-msvc.exe
 
     steps:
       - uses: actions/checkout@v3

--- a/helix-cli/install.sh
+++ b/helix-cli/install.sh
@@ -106,18 +106,48 @@ set_install_dir() {
 
 # Detect platform and architecture
 detect_platform() {
-    local os arch
+    local target
 
-    # Detect OS
+    # Detect OS and architecture combination to match Rust targets
     case "$OSTYPE" in
         linux*)
-            os="linux"
+            case "$(uname -m)" in
+                x86_64|amd64)
+                    target="x86_64-unknown-linux-gnu"
+                    ;;
+                aarch64|arm64)
+                    target="aarch64-unknown-linux-gnu"
+                    ;;
+                *)
+                    log_error "Unsupported architecture: $(uname -m)"
+                    exit 1
+                    ;;
+            esac
             ;;
         darwin*)
-            os="macos"
+            case "$(uname -m)" in
+                x86_64|amd64)
+                    target="x86_64-apple-darwin"
+                    ;;
+                aarch64|arm64)
+                    target="aarch64-apple-darwin"
+                    ;;
+                *)
+                    log_error "Unsupported architecture: $(uname -m)"
+                    exit 1
+                    ;;
+            esac
             ;;
         msys*|cygwin*)
-            os="windows"
+            case "$(uname -m)" in
+                x86_64|amd64)
+                    target="x86_64-pc-windows-msvc"
+                    ;;
+                *)
+                    log_error "Unsupported architecture: $(uname -m)"
+                    exit 1
+                    ;;
+            esac
             ;;
         *)
             log_error "Unsupported OS: $OSTYPE"
@@ -125,27 +155,13 @@ detect_platform() {
             ;;
     esac
 
-    # Detect architecture
-    case "$(uname -m)" in
-        x86_64|amd64)
-            arch="amd64"
-            ;;
-        aarch64|arm64)
-            arch="arm64"
-            ;;
-        *)
-            log_error "Unsupported architecture: $(uname -m)"
-            exit 1
-            ;;
-    esac
-
     # Set binary name with extension for Windows
     local binary_ext=""
-    if [[ "$os" == "windows" ]]; then
+    if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
         binary_ext=".exe"
     fi
 
-    echo "${BINARY_NAME}-cli-${os}-${arch}${binary_ext}"
+    echo "${BINARY_NAME}-${target}${binary_ext}"
 }
 
 # Get latest release version from GitHub


### PR DESCRIPTION
## Description
Changes asset names in the releases to contain the rust target triple. Hopefully this fixes the update command.

Since v2, we use the self_update crate, which is looking for the release assets' names containing the target triple. Our release workflow names the assets in a more human readable way, which breaks this.

Luckily, v1 curls the install.sh script, so we can change future release asset names as long as install.sh is modified, so this fix should fix updates in v2 without breaking v1 update.

We don't have to worry about not using more human-readable names for assets as we advertise installation via a shell script.

## Important to do while merging
- [x] Upload the new install.sh to S3.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-30 09:25:43 UTC

<h3>Summary</h3>
This PR fixes a critical issue with the CLI update command in v2 by changing how release assets are named in GitHub workflows and the install script. The core problem was that the `self_update` crate used in CLI v2 expects release asset names to follow Rust target triple conventions (like `helix-x86_64-unknown-linux-gnu`), but the existing GitHub Actions workflows were creating assets with human-readable names (like `helix-cli-linux-amd64`).

The fix involves three coordinated changes:
1. **GitHub workflows** (`cli.yml` and `cliv2.yml`) now use Rust target triple naming for release assets
2. **Install script** (`install.sh`) updated its platform detection logic to generate the same target triple names
3. This maintains backward compatibility since v1 installations use the install script via curl, while enabling v2's self-update functionality

The change represents a strategic decision to prioritize tooling compatibility over human-readable asset names, which is acceptable since the project advertises installation via the shell script rather than direct asset downloads.

PR Description Notes:
- Remember to upload the new install.sh to S3 when merging

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `.github/workflows/cliv2.yml` | 5/5 | Updates binary naming matrix from human-readable names to Rust target triple format for v2 CLI compatibility |
| `.github/workflows/cli.yml` | 4/5 | Changes release asset naming from human-readable to target triple format to fix self_update crate compatibility |
| `helix-cli/install.sh` | 4/5 | Rewrites platform detection logic to use Rust target triples matching the new GitHub workflow asset names |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant GitHub
    participant CreateJob as "create_release job"
    participant ZendeskAction as "zendesk/action-create-release"
    participant BuildJob as "build job (matrix)"
    participant RustToolchain as "Rust Toolchain"
    participant UploadAction as "upload-release-asset"

    User->>GitHub: "Trigger workflow_dispatch"
    GitHub->>CreateJob: "Start create_release job"
    CreateJob->>GitHub: "Checkout repository"
    CreateJob->>ZendeskAction: "Create GitHub Release"
    ZendeskAction->>GitHub: "Create release with auto-incremented version"
    ZendeskAction-->>CreateJob: "Return upload_url and release_id"
    
    CreateJob-->>BuildJob: "Pass release outputs"
    
    par Build for each platform
        BuildJob->>GitHub: "Checkout repository"
        BuildJob->>RustToolchain: "Install Rust toolchain for target"
        RustToolchain-->>BuildJob: "Toolchain ready"
        BuildJob->>BuildJob: "Build binary for target platform"
        Note over BuildJob: "cd helix-cli && cargo build --release --target {target}"
        BuildJob->>UploadAction: "Upload binary as release asset"
        Note over UploadAction: "Asset named with target triple (e.g., helix-x86_64-unknown-linux-gnu)"
        UploadAction->>GitHub: "Upload asset to release"
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->