### PR TITLE
fix (mcp): fixing mcp variant issue

### DIFF
--- a/helix-db/src/helix_gateway/mcp/tools.rs
+++ b/helix-db/src/helix_gateway/mcp/tools.rs
@@ -1,7 +1,9 @@
 use crate::{
     debug_println,
     helix_engine::{
-        bm25::bm25::{BM25Flatten, HBM25Config, BM25}, storage_core::HelixGraphStorage, traversal_core::{
+        bm25::bm25::{BM25, BM25Flatten, HBM25Config},
+        storage_core::HelixGraphStorage,
+        traversal_core::{
             ops::{
                 bm25::search_bm25::SearchBM25Adapter,
                 g::G,
@@ -18,10 +20,12 @@ use crate::{
                 vectors::{brute_force_search::BruteForceSearchVAdapter, search::SearchVAdapter},
             },
             traversal_value::{Traversable, TraversalValue},
-        }, types::GraphError, vector_core::vector::HVector
+        },
+        types::GraphError,
+        vector_core::vector::HVector,
     },
     helix_gateway::{
-        embedding_providers::embedding_providers::{get_embedding_model, EmbeddingModel},
+        embedding_providers::embedding_providers::{EmbeddingModel, get_embedding_model},
         mcp::mcp::{MCPConnection, MCPHandler, MCPHandlerSubmission, MCPToolInput, McpBackend},
     },
     protocol::{response::Response, return_values::ReturnValue, value::Value},
@@ -385,12 +389,14 @@ impl<'a> McpTools<'a> for McpBackend {
     ) -> Result<Vec<TraversalValue>, GraphError> {
         let db = Arc::clone(&self.db);
 
+        let iter = db.nodes_db.lazily_decode_data().iter(txn).unwrap();
+
         let iter = NFromType {
-            iter: db.nodes_db.lazily_decode_data().iter(txn).unwrap(),
+            iter,
             label: &node_type,
         };
 
-        let result = iter.collect::<Result<Vec<_>, _>>();
+        let result = Ok(iter.filter_map(|item| item.ok()).collect::<Vec<_>>());
         debug_println!("result: {:?}", result);
         result
     }
@@ -408,7 +414,7 @@ impl<'a> McpTools<'a> for McpBackend {
             label: &edge_type,
         };
 
-        let result = iter.collect::<Result<Vec<_>, _>>();
+        let result = Ok(iter.filter_map(|item| item.ok()).collect::<Vec<_>>());
         debug_println!("result: {:?}", result);
         result
     }
@@ -794,10 +800,7 @@ fn _search_keyword(
                 "Error checking BM25 metadata: {:?} - returning empty results",
                 e
             );
-            println!(
-                "Error checking BM25 metadata: {e:?} - returning empty results",
-
-            );
+            println!("Error checking BM25 metadata: {e:?} - returning empty results",);
             Err(GraphError::from(
                 "Error checking BM25 metadata - returning empty results",
             ))


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-30 10:04:57 UTC

<h3>Summary</h3>
This PR fixes critical error handling issues in the MCP (Model Context Protocol) tools implementation within HelixDB's gateway. The Model Context Protocol is used by AI agents to discover and traverse graph data, making robust error handling essential for system stability.

The primary change addresses a significant bug where database iteration operations in `n_from_type` and `e_from_type` methods were using `collect::<Result<Vec<_>, _>>()`, which would cause the entire operation to fail if any single item encountered an error during iteration. This "fail-fast" behavior is problematic for MCP tools because it means a single corrupted or problematic database item could crash the entire graph traversal operation.

The fix changes the error handling strategy to use `filter_map(|item| item.ok()).collect::<Vec<_>>()`, which gracefully filters out failed items and continues processing successful ones. This is a more resilient approach that allows MCP operations to continue even when encountering individual item errors.

Additional improvements include reorganizing import statements for better readability, cleaning up print statement formatting, and adding explicit iterator binding to improve code clarity. These changes fit well with HelixDB's architecture as a graph-vector database where resilient data access patterns are crucial for AI agent integration.

**PR Description Notes:**
- The PR title "trying to fix" and empty description/related issues sections suggest this may have been created hastily to address an urgent issue
- The checklist items are not marked as complete, indicating this may need additional review

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/helix_gateway/mcp/tools.rs | 4/5 | Fixed critical error handling in MCP tools to prevent crashes during database iteration by switching from fail-fast to filter-out-errors approach |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant MCPConnection
    participant McpBackend
    participant HelixGraphStorage
    participant BM25Index
    participant VectorSearch
    participant Database

    User->>MCPConnection: "Submit tool request (out_step, in_step, search, etc.)"
    MCPConnection->>McpBackend: "Execute tool with args"
    
    alt Graph Traversal Operations
        McpBackend->>HelixGraphStorage: "Get edge iterators"
        HelixGraphStorage->>Database: "Query out_edges_db/in_edges_db"
        Database-->>HelixGraphStorage: "Return edge data"
        HelixGraphStorage-->>McpBackend: "Return traversal iterators"
        McpBackend-->>MCPConnection: "Return traversal results"
    
    else Search Operations
        alt BM25 Search
            McpBackend->>BM25Index: "Create temporary index"
            McpBackend->>BM25Index: "Insert documents from connection items"
            McpBackend->>Database: "Execute BM25 search query"
            Database-->>McpBackend: "Return search results"
            McpBackend->>BM25Index: "Abort transaction (cleanup)"
        
        else Vector Search
            McpBackend->>VectorSearch: "Get embedding model"
            VectorSearch->>VectorSearch: "Generate embedding from text"
            McpBackend->>Database: "Execute vector search"
            Database-->>McpBackend: "Return vector search results"
        end
        
        McpBackend-->>MCPConnection: "Return search results"
    
    else Filter Operations
        McpBackend->>McpBackend: "Apply property filters"
        McpBackend->>HelixGraphStorage: "Execute filter traversals"
        HelixGraphStorage-->>McpBackend: "Return filtered results"
        McpBackend-->>MCPConnection: "Return filtered items"
    end
    
    MCPConnection-->>User: "Return final results"
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->