### PR TITLE
Added Manta Graph button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![GitHub Repo stars](https://img.shields.io/github/stars/HelixDB/helix-db)](https://github.com/HelixDB/helix-db/stargazers)
 [![Discord](https://img.shields.io/discord/1354148209005559819?logo=discord)](https://discord.gg/2stgMPr5BD)
 [![LOC](https://img.shields.io/endpoint?url=https://ghloc.vercel.app/api/HelixDB/helix-db/badge?filter=.rs$,.sh$&style=flat&logoColor=white&label=Lines%20of%20Code)](https://github.com/HelixDB/helix-db)
+[![Manta Graph](https://getmanta.ai/api/badges?text=Manta%20Graph&link=helixdb)](https://getmanta.ai/helixdb)
 
 <a href="https://www.ycombinator.com/launches/Naz-helixdb-the-database-for-rag-ai" target="_blank"><img src="https://www.ycombinator.com/launches/Naz-helixdb-the-database-for-rag-ai/upvote_embed.svg" alt="Launch YC: HelixDB - The Database for Intelligence" style="margin-left: 12px;"/></a>
 


### PR DESCRIPTION
Manta Graph can be opened through a button in README, to see the solution in a form of interactive graph.

<img width="1440" height="1209" alt="image" src="https://github.com/user-attachments/assets/bf4b8747-cfc5-4246-bb5a-1aa4e8148fcb" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-12 19:34:37 UTC

<h3>Summary</h3>

Added a Manta Graph badge to the README badge section that links to an interactive graph visualization of the repository at `getmanta.ai/helixdb`.

- Badge uses standard markdown badge format consistent with existing badges
- Both the badge image URL and target link are verified to be accessible
- Placement is appropriate among other project badges (line 21)
- No functional or documentation issues identified

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| README.md | 5/5 | Added Manta Graph badge to badge section - safe documentation change |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub README
    participant Badge as Manta Badge API
    participant Manta as Manta Graph Site
    
    Dev->>GH: Add Manta Graph badge markdown
    Note over GH: Badge line 21:<br/>[![Manta Graph](badge_url)](link_url)
    
    User->>GH: View README.md
    GH->>Badge: Request badge image<br/>(getmanta.ai/api/badges?text=...)
    Badge-->>GH: Return SVG badge image
    GH->>User: Display README with badge
    
    User->>GH: Click Manta Graph badge
    GH->>Manta: Redirect to getmanta.ai/helixdb
    Manta-->>User: Show interactive graph visualization
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->