### PR TITLE
fix(hql): compilation error for AddE with borrowed IDs in FOR loops

### DIFF
--- a/helix-db/src/utils/id.rs
+++ b/helix-db/src/utils/id.rs
@@ -25,6 +25,10 @@ impl ID {
         self.0
     }
 
+    pub fn id(&self) -> u128 {
+        self.0
+    }
+
     pub fn stringify(&self) -> String {
         uuid::Uuid::from_u128(self.0).to_string()
     }
@@ -117,14 +121,12 @@ pub fn v6_uuid() -> u128 {
     uuid::Uuid::now_v6(&[1, 2, 3, 4, 5, 6]).as_u128()
 }
 
-
 #[cfg(test)]
 mod tests {
     use sonic_rs::json;
 
     use super::*;
 
-    
     #[test]
     fn test_uuid_deserialization() {
         let uuid = json!({ "id": "1f07ae4b-e354-6660-b5f0-fd3ce8bc4b49" });
@@ -134,9 +136,11 @@ mod tests {
             id: ID,
         }
 
-
         let deserialized: IDWrapper = sonic_rs::from_value(&uuid).unwrap();
-        assert_eq!(deserialized.id.stringify(), "1f07ae4b-e354-6660-b5f0-fd3ce8bc4b49");
+        assert_eq!(
+            deserialized.id.stringify(),
+            "1f07ae4b-e354-6660-b5f0-fd3ce8bc4b49"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR fixes a compilation error in plural AddE queries within FOR loops, where ID variables are references.

## Problem

Queries like:
```ts
QUERY AddEdges (edges: [{from_id: ID, to_id: ID, relationship_name: String, properties: String}]) =>
	FOR {from_id, to_id, relationship_name, properties} IN edges {
		AddE<MyEdge>({
			relationship_name: relationship_name,
			properties: properties
		})::From(from_id)::To(to_id)
	}
	RETURN "Edges are added successfully"
```
failed with "no method named id found for &ID" because the generator produced from_id.id(), but ID  (references from iterating &data.edges) has no .id() method, and references don't dereference automatically here.

## Solution

Added `.id()` method to the ID struct in `utils/id.rs`.

Now both work seamlessly:
- `ID.id()` returns `u128`
- `&ID.id()` works through Rust's auto-deref mechanism

This allows the code generator to use `.id()` consistently for AddE identifier references in FOR loops.

## Related Issues
None

## Checklist when merging to main

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
None

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-26 13:17:58 UTC

<h3>Greptile Summary</h3>


This PR elegantly fixes a compilation error where AddE queries with borrowed ID references in FOR loops failed because `&ID` didn't have an `.id()` method.

**Key Changes:**
- Added `.id()` method to the `ID` struct in `utils/id.rs` that returns `u128`
- Leverages Rust's auto-deref mechanism so both `ID.id()` and `&ID.id()` work seamlessly
- This allows the code generator to consistently use `.id()` for all ID accessor patterns
- Minor formatting cleanup in test code (whitespace fixes)

**Solution Quality:**
This is a cleaner approach compared to the previous attempt (commit 95e1a17c) which changed the generator to use `.inner()` instead. By adding the `.id()` method, the fix maintains consistency with the existing `.inner()` method while providing a more intuitive API that works with both owned and borrowed values through auto-deref.

**Impact:**
The fix enables plural AddE queries within FOR loops to compile correctly when ID variables are references, as shown in the example query in the PR description.

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/utils/id.rs | 5/5 | Added `.id()` method to ID struct for unified accessor interface, enabling both owned and borrowed IDs to use the same method call. Also includes minor formatting fixes. |
| helix-db/src/helixc/analyzer/utils.rs | 5/5 | No functional changes in this file - the PR only adds the `.id()` method to the ID struct to support the existing code generator that calls `.id()` on identifier references. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as User Query
    participant Parser as HQL Parser
    participant Analyzer as Semantic Analyzer
    participant CodeGen as Code Generator
    participant ID as ID Struct
    
    User->>Parser: AddE query with FOR loop
    Note over User: FOR {from_id, to_id} IN edges<br/>AddE::From(from_id)::To(to_id)
    
    Parser->>Analyzer: Parse AddE with identifiers
    Analyzer->>Analyzer: Validate identifiers in scope
    Analyzer->>CodeGen: gen_id_access_or_param(from_id)
    Note over CodeGen: Generates: from_id.id()
    
    CodeGen->>ID: Call .id() on &ID
    Note over ID: Before: &ID had no .id() method<br/>Compiler error: "no method named id"
    
    ID-->>CodeGen: Now: auto-deref to ID.id()
    Note over ID: Rust auto-deref: &ID -> ID<br/>Returns u128
    
    CodeGen-->>Analyzer: GeneratedValue with u128
    Analyzer-->>User: Compiled query code
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->