### PR TITLE
feat(hql): Add From<ID> impl for ReturnValue

### DIFF
--- a/helix-db/src/protocol/return_values.rs
+++ b/helix-db/src/protocol/return_values.rs
@@ -16,6 +16,7 @@ use crate::{
         count::Count,
         filterable::{Filterable, FilterableType},
         group_by::GroupBy,
+        id::ID,
         items::{Edge, Node},
     },
 };
@@ -549,6 +550,12 @@ impl From<f64> for ReturnValue {
 impl From<f32> for ReturnValue {
     fn from(float: f32) -> Self {
         ReturnValue::Value(Value::F32(float))
+    }
+}
+
+impl From<ID> for ReturnValue {
+    fn from(id: ID) -> Self {
+        ReturnValue::Value(Value::Id(id))
     }
 }
 


### PR DESCRIPTION
## Description

Queries returning ID parameters, such as:
```ts
QUERY DeleteNode (node_id: ID) =>
    DROP N<MyNode>(node_id)
    RETURN {node_id: node_id}
```
failed to compile with error: 

```
the traitfbound helix_db::protocol::return_values::ReturnValue: std::convert::From<helix_db::utils::id::ID> is not satisfied.
```

## Solution

Added impl From<ID> for ReturnValue in protocol/return_values.rs, delegating to ReturnValue::Value(Value::Id(id)). This allows direct conversion of ID to ReturnValue for query returns.

## Related Issues
None


## Checklist when merging to main

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
None

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-24 16:51:05 UTC

<h3>Greptile Summary</h3>


Added `From<ID>` trait implementation for `ReturnValue` to fix compilation errors when returning ID parameters in HQL queries.

**Changes:**
- Added import for `id::ID` type in `return_values.rs:19`
- Implemented `From<ID> for ReturnValue` at lines 556-560, converting ID to `ReturnValue::Value(Value::Id(id))`

**Analysis:**
The implementation correctly uses the `Value::Id` variant to preserve type information. This allows queries like `RETURN {node_id: node_id}` to compile successfully when the parameter is of type ID. The implementation is consistent with other From implementations in the file and properly delegates to the existing `Value::Id` variant.

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/protocol/return_values.rs | 5/5 | Added `From<ID>` impl to enable ID-to-ReturnValue conversion, correctly using `Value::Id` variant |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Query as HQL Query
    participant Compiler as Query Compiler
    participant ID as ID Type
    participant ReturnValue as ReturnValue
    participant Value as Value Enum
    
    Query->>Compiler: RETURN {node_id: node_id}
    Compiler->>ID: Get ID parameter
    ID->>ReturnValue: From<ID>::from(id)
    ReturnValue->>Value: Value::Id(id)
    Value->>ReturnValue: ReturnValue::Value(Value::Id(id))
    ReturnValue->>Query: Return compiled result
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->