### PR TITLE
fix(hql): DROP operation on empty traversals

### DIFF
--- a/helix-db/src/helix_engine/traversal_core/ops/util/drop.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/util/drop.rs
@@ -1,7 +1,7 @@
 use crate::helix_engine::{
     bm25::bm25::BM25,
-    traversal_core::traversal_value::TraversalValue,
     storage_core::{HelixGraphStorage, storage_methods::StorageMethods},
+    traversal_core::traversal_value::TraversalValue,
     types::GraphError,
 };
 use heed3::RwTxn;
@@ -26,8 +26,9 @@ where
                     TraversalValue::Node(node) => match storage.drop_node(txn, &node.id) {
                         Ok(_) => {
                             if let Some(bm25) = &storage.bm25
-                                && let Err(e) = bm25.delete_doc(txn, node.id) {
-                                    println!("failed to delete doc from bm25: {e}");
+                                && let Err(e) = bm25.delete_doc(txn, node.id)
+                            {
+                                println!("failed to delete doc from bm25: {e}");
                             }
                             println!("Dropped node: {:?}", node.id);
                             Ok(())
@@ -42,6 +43,7 @@ where
                         Ok(_) => Ok(()),
                         Err(e) => Err(e),
                     },
+                    TraversalValue::Empty => Ok(()),
                     _ => Err(GraphError::ConversionError(format!(
                         "Incorrect Type: {item:?}"
                     ))),


### PR DESCRIPTION
## Description

This PR fixes a runtime error in DROP operations when attempting to drop non-existent nodes, ensuring graceful handling of empty traversals.

## Problem

Queries like `DROP N<NodeType>(id)` on non-existent IDs failed with "Conversion error: Incorrect Type: Empty" because drop_traversal did not handle TraversalValue::Empty returned by collect_to_obj().

## Solution

Added `TraversalValue::Empty => Ok(())`, in the match statement of drop_traversal. This treats empty traversals as successful no-ops.

## Related Issues
None

## Checklist when merging to main

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
```
curl -X POST http://localhost:6969/DeleteNode \
      -H "Content-Type: application/json" \
      -d '{
      "node_id": "550e8400-e29b-41d4-a716-446655440007"
      }'

Conversion error: Incorrect Type: Empty⏎
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-24 19:24:02 UTC

<h3>Greptile Summary</h3>


Fixed runtime error when attempting to DROP non-existent nodes by adding `TraversalValue::Empty => Ok(())` case to the match statement in `drop_traversal()`.

- Resolved "Conversion error: Incorrect Type: Empty" error when dropping nodes by ID that don't exist
- Empty traversals now treated as successful no-ops, consistent with how other parts of the codebase handle `TraversalValue::Empty`
- Minor formatting improvements applied to let-chain syntax for consistency

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/helix_engine/traversal_core/ops/util/drop.rs | 5/5 | Added handling for `TraversalValue::Empty` case in `drop_traversal` to gracefully handle dropping non-existent nodes; minor formatting fixes applied |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant HQL
    participant drop_traversal
    participant collect_to_obj
    participant Storage

    Client->>HQL: DROP N<NodeType>(non_existent_id)
    HQL->>collect_to_obj: Query for node by ID
    collect_to_obj->>Storage: Fetch node
    Storage-->>collect_to_obj: No results found
    collect_to_obj-->>HQL: TraversalValue::Empty
    HQL->>drop_traversal: Process traversal items
    alt Empty traversal (after fix)
        drop_traversal-->>HQL: Ok(()) - no-op
        HQL-->>Client: Success
    else Empty traversal (before fix)
        drop_traversal-->>HQL: ConversionError
        HQL-->>Client: Error: "Incorrect Type: Empty"
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->