### PR TITLE
feat(hql): Add String Support for IS_IN Operations in Queries

### DIFF
--- a/helix-db/src/protocol/value.rs
+++ b/helix-db/src/protocol/value.rs
@@ -1620,6 +1620,15 @@ impl IntoPrimitive<Date> for Value {
     }
 }
 
+impl IntoPrimitive<String> for Value {
+    fn into_primitive(&self) -> &String {
+        match self {
+            Value::String(s) => s,
+            _ => panic!("Value is not a String"),
+        }
+    }
+}
+
 #[test]
 fn test_value_eq() {
     assert_eq!(Value::I64(1), Value::I64(1));


### PR DESCRIPTION
## Description
This PR adds support for IS_IN operations on string properties by implementing IntoPrimitive<String> for the Value enum. Previously, IS_IN only worked with numeric types due to trait constraints.

## Problem

Queries using IS_IN with string arrays failed to compile with `trait bound IntoPrimitive<String> not satisfied`. For example:

• Schema:
```ts
N::MyNode { 
  INDEX field: String,
   ...
 }
```
• Query: 
```ts
QUERY GetNodes (fields: [String]) =>
	node <- N<MyNode>::WHERE(_::{field}::IS_IN(fields))
 }
```
• Error: Compilation failed because Value::is_in couldn't handle strings.

## Related Issues
None

## Checklist when merging to main
- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
None

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-26 07:44:19 UTC

<h3>Greptile Summary</h3>


Enables `IS_IN` operations on string properties by implementing `IntoPrimitive<String>` trait for the `Value` enum.

**Changes:**
- Added `IntoPrimitive<String>` implementation at `value.rs:1623-1630` that extracts the string reference from `Value::String` variant
- Mirrors existing implementations for numeric types (i8, i16, i32, i64, u8, u16, u32, u64, u128, f32, f64), booleans, dates, and IDs
- Satisfies trait bounds required by the `is_in<T>()` method at line 115-121

**Implementation:**
The implementation correctly follows the pattern of other `IntoPrimitive` implementations. The `is_in` method requires both `IntoPrimitive<T>` and `Into<T>` trait bounds, and `Into<T>` is already satisfied by the existing `From<Value> for String` implementation at lines 992-999.

**Impact:**
This unblocks HQL queries that use `IS_IN` with string arrays, such as filtering nodes by string field membership in a provided list.

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/protocol/value.rs | 5/5 | Added `IntoPrimitive<String>` implementation to enable IS_IN operations on string properties |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Query as HQL Query
    participant Compiler as HelixQL Compiler
    participant Generator as Code Generator
    participant Runtime as Runtime (is_in method)
    participant Value as Value Type

    Query->>Compiler: QUERY with IS_IN(field_array)
    Compiler->>Compiler: Validate field type (String)
    Compiler->>Generator: Generate is_in() call
    Generator->>Generator: Create IsIn BoolOp
    Generator->>Runtime: Generate: v.is_in(field_array)
    Runtime->>Value: Call is_in<String>()
    Value->>Value: Check IntoPrimitive<String> trait bound
    Value->>Value: into_primitive() extracts &String
    Value->>Runtime: values.contains(&String)
    Runtime->>Query: Return boolean result
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->