### PR TITLE
fix(hql): handle TraversalValue::Empty in DROP operations

### DIFF
--- a/helix-db/src/helix_engine/traversal_core/ops/util/drop.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/util/drop.rs
@@ -48,6 +48,7 @@ where
                             Err(e) => Err(e),
                         }
                     }
+                    TraversalValue::Empty => Ok(()),
                     _ => Err(GraphError::ConversionError(format!(
                         "Incorrect Type: {item:?}"
                     ))),


### PR DESCRIPTION
## Summary

This PR integrates the fix from #670 into the `arena-implementation` branch. It resolves runtime errors when attempting to DROP non-existent nodes, edges, or vectors.

## Problem

Queries attempting to drop non-existent items failed with:
```
Conversion error: Incorrect Type: Empty
```

This occurred because `drop_traversal` did not handle `TraversalValue::Empty` returned when querying for non-existent items.

## Solution

Added `TraversalValue::Empty => Ok(())` case in the match statement of `drop_traversal` in `helix-db/src/helix_engine/traversal_core/ops/util/drop.rs:51`.

This treats empty traversals as successful no-ops, making DROP operations idempotent.

## Testing

- ✅ `cargo check` passes with no errors
- ✅ All 109 `helix_engine` tests pass, including all DROP-related tests

## Related

- Integrates fix from PR #670
- No changes needed to helixc generator - the fix automatically applies to generated code

Co-Authored-By: ishaksebsib

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-29 11:44:54 UTC

<h3>Greptile Summary</h3>


Added handling for `TraversalValue::Empty` in DROP operations to prevent runtime errors when attempting to drop non-existent nodes, edges, or vectors.

- Fixed "Conversion error: Incorrect Type: Empty" by treating empty traversals as successful no-ops
- Implementation is consistent with how `TraversalValue::Empty` is handled elsewhere in the codebase (returns default/neutral values)
- Makes DROP operations idempotent, which is expected behavior for deletion operations

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/helix_engine/traversal_core/ops/util/drop.rs | 5/5 | Added `TraversalValue::Empty` handling to gracefully treat empty traversals as no-ops in DROP operations |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant HQL
    participant drop_traversal
    participant collect_to_obj
    participant Storage

    Client->>HQL: DROP N<NodeType>(non_existent_id)
    HQL->>collect_to_obj: Query for node by ID
    collect_to_obj->>Storage: Fetch node
    Storage-->>collect_to_obj: No results found
    collect_to_obj-->>HQL: TraversalValue::Empty
    HQL->>drop_traversal: Process traversal items
    alt Empty traversal (after fix)
        drop_traversal-->>HQL: Ok(()) - no-op
        HQL-->>Client: Success
    else Empty traversal (before fix)
        drop_traversal-->>HQL: ConversionError
        HQL-->>Client: Error: "Incorrect Type: Empty"
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->