### PR TITLE
Integrate PR #666: Fix IS_IN validation and reserved property handling

### DIFF
--- a/helix-db/src/helixc/analyzer/utils.rs
+++ b/helix-db/src/helixc/analyzer/utils.rs
@@ -5,7 +5,7 @@ use crate::{
     helixc::{
         analyzer::{Ctx, errors::push_query_err, types::Type},
         generator::{
-            traversal_steps::Step,
+            traversal_steps::{Step, ReservedProp},
             utils::{GenRef, GeneratedValue},
         },
         parser::{location::Loc, types::*},
@@ -185,8 +185,15 @@ pub(super) fn get_field_type_from_item_fields(
 
 pub(super) fn gen_property_access(name: &str) -> Step {
     match name {
-        "id" => Step::PropertyFetch(GenRef::Literal("id".to_string())),
-        "ID" => Step::PropertyFetch(GenRef::Literal("id".to_string())),
+        "id" | "ID" | "Id" => Step::ReservedPropertyAccess(ReservedProp::Id),
+        "label" | "Label" => Step::ReservedPropertyAccess(ReservedProp::Label),
+        "version" | "Version" => Step::ReservedPropertyAccess(ReservedProp::Version),
+        "from_node" | "fromNode" | "FromNode" => Step::ReservedPropertyAccess(ReservedProp::FromNode),
+        "to_node" | "toNode" | "ToNode" => Step::ReservedPropertyAccess(ReservedProp::ToNode),
+        "deleted" | "Deleted" => Step::ReservedPropertyAccess(ReservedProp::Deleted),
+        "level" | "Level" => Step::ReservedPropertyAccess(ReservedProp::Level),
+        "distance" | "Distance" => Step::ReservedPropertyAccess(ReservedProp::Distance),
+        "data" | "Data" => Step::ReservedPropertyAccess(ReservedProp::Data),
         n => Step::PropertyFetch(GenRef::Literal(n.to_string())),
     }
 }

--- a/hql-tests/tests/is_in/helix.toml
+++ b/hql-tests/tests/is_in/helix.toml
@@ -1,0 +1,9 @@
+[project]
+name = "mcp_macro"
+queries = "."
+
+[local.dev]
+port = 6969
+build_mode = "debug"
+
+[cloud]

--- a/hql-tests/tests/is_in/queries.hx
+++ b/hql-tests/tests/is_in/queries.hx
@@ -1,0 +1,13 @@
+N::MyNode { 
+    field: String,
+}
+
+
+QUERY GetNodes (fields: [String]) =>
+	node <- N<MyNode>::WHERE(_::{field}::IS_IN(fields))
+    RETURN node
+
+
+QUERY GetNodesByID (node_ids: [ID]) =>
+	node <- N<MyNode>::WHERE(_::{id}::IS_IN(node_ids))
+    RETURN node

--- a/hql-tests/tests/is_in/queries.rs
+++ b/hql-tests/tests/is_in/queries.rs
@@ -1,0 +1,230 @@
+
+// DEFAULT CODE
+// use helix_db::helix_engine::traversal_core::config::Config;
+
+// pub fn config() -> Option<Config> {
+//     None
+// }
+
+
+
+use bumpalo::Bump;
+use heed3::RoTxn;
+use helix_macros::{handler, tool_call, mcp_handler, migration};
+use helix_db::{
+    helix_engine::{
+        traversal_core::{
+            config::{Config, GraphConfig, VectorConfig},
+            ops::{
+                bm25::search_bm25::SearchBM25Adapter,
+                g::G,
+                in_::{in_::InAdapter, in_e::InEdgesAdapter, to_n::ToNAdapter, to_v::ToVAdapter},
+                out::{
+                    from_n::FromNAdapter, from_v::FromVAdapter, out::OutAdapter, out_e::OutEdgesAdapter,
+                },
+                source::{
+                    add_e::AddEAdapter,
+                    add_n::AddNAdapter,
+                    e_from_id::EFromIdAdapter,
+                    e_from_type::EFromTypeAdapter,
+                    n_from_id::NFromIdAdapter,
+                    n_from_index::NFromIndexAdapter,
+                    n_from_type::NFromTypeAdapter,
+                    v_from_id::VFromIdAdapter,
+                    v_from_type::VFromTypeAdapter
+                },
+                util::{
+                    dedup::DedupAdapter, drop::Drop, exist::Exist, filter_mut::FilterMut,
+                    filter_ref::FilterRefAdapter, map::MapAdapter, paths::{PathAlgorithm, ShortestPathAdapter},
+                    range::RangeAdapter, update::UpdateAdapter, order::OrderByAdapter,
+                    aggregate::AggregateAdapter, group_by::GroupByAdapter, count::CountAdapter,
+                },
+                vectors::{
+                    brute_force_search::BruteForceSearchVAdapter, insert::InsertVAdapter,
+                    search::SearchVAdapter,
+                },
+            },
+            traversal_value::TraversalValue,
+        },
+        types::GraphError,
+        vector_core::vector::HVector,
+    },
+    helix_gateway::{
+        embedding_providers::{EmbeddingModel, get_embedding_model},
+        router::router::{HandlerInput, IoContFn},
+        mcp::mcp::{MCPHandlerSubmission, MCPToolInput, MCPHandler}
+    },
+    node_matches, props, embed, embed_async,
+    field_addition_from_old_field, field_type_cast, field_addition_from_value,
+    protocol::{
+        response::Response,
+        value::{casting::{cast, CastType}, Value},
+        format::Format,
+    },
+    utils::{
+        count::Count,
+        id::{ID, uuid_str},
+        items::{Edge, Node},
+        properties::ImmutablePropertiesMap,
+    },
+};
+use sonic_rs::{Deserialize, Serialize, json};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Instant;
+use chrono::{DateTime, Utc};
+
+// Re-export scalar types for generated code
+type I8 = i8;
+type I16 = i16;
+type I32 = i32;
+type I64 = i64;
+type U8 = u8;
+type U16 = u16;
+type U32 = u32;
+type U64 = u64;
+type U128 = u128;
+type F32 = f32;
+type F64 = f64;
+    
+pub fn config() -> Option<Config> {
+return Some(Config {
+vector_config: Some(VectorConfig {
+m: Some(16),
+ef_construction: Some(128),
+ef_search: Some(768),
+}),
+graph_config: Some(GraphConfig {
+secondary_indices: Some(vec![]),
+}),
+db_max_size_gb: Some(10),
+mcp: Some(true),
+bm25: Some(true),
+schema: Some(r#"{
+  "schema": {
+    "nodes": [
+      {
+        "name": "MyNode",
+        "properties": {
+          "label": "String",
+          "id": "ID",
+          "field": "String"
+        }
+      }
+    ],
+    "vectors": [],
+    "edges": []
+  },
+  "queries": [
+    {
+      "name": "GetNodesByID",
+      "parameters": {
+        "node_ids": "Array(ID)"
+      },
+      "returns": [
+        "node"
+      ]
+    },
+    {
+      "name": "GetNodes",
+      "parameters": {
+        "fields": "Array(String)"
+      },
+      "returns": [
+        "node"
+      ]
+    }
+  ]
+}"#.to_string()),
+embedding_model: Some("text-embedding-ada-002".to_string()),
+graphvis_node_label: None,
+})
+}
+
+pub struct MyNode {
+    pub field: String,
+}
+
+
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct GetNodesByIDInput {
+
+pub node_ids: Vec<ID>
+}
+#[derive(Serialize)]
+pub struct GetNodesByIDNodeReturnType<'a> {
+    pub id: &'a str,
+    pub label: &'a str,
+    pub field: Option<&'a Value>,
+}
+
+#[handler]
+pub fn GetNodesByID (input: HandlerInput) -> Result<Response, GraphError> {
+let db = Arc::clone(&input.graph.storage);
+let data = input.request.in_fmt.deserialize::<GetNodesByIDInput>(&input.request.body)?;
+let arena = Bump::new();
+let txn = db.graph_env.read_txn().map_err(|e| GraphError::New(format!("Failed to start read transaction: {:?}", e)))?;
+    let node = G::new(&db, &txn, &arena)
+.n_from_type("MyNode")
+
+.filter_ref(|val, txn|{
+                if let Ok(val) = val {
+                    Ok(Value::Id(ID::from(val.id)).is_in(&data.node_ids))
+                } else {
+                    Ok(false)
+                }
+            }).collect::<Result<Vec<_>, _>>()?;
+let response = json!({
+    "node": node.iter().map(|node| GetNodesByIDNodeReturnType {
+        id: uuid_str(node.id(), &arena),
+        label: node.label(),
+        field: node.get_property("field"),
+    }).collect::<Vec<_>>()
+});
+txn.commit().map_err(|e| GraphError::New(format!("Failed to commit transaction: {:?}", e)))?;
+Ok(input.request.out_fmt.create_response(&response))
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct GetNodesInput {
+
+pub fields: Vec<String>
+}
+#[derive(Serialize)]
+pub struct GetNodesNodeReturnType<'a> {
+    pub id: &'a str,
+    pub label: &'a str,
+    pub field: Option<&'a Value>,
+}
+
+#[handler]
+pub fn GetNodes (input: HandlerInput) -> Result<Response, GraphError> {
+let db = Arc::clone(&input.graph.storage);
+let data = input.request.in_fmt.deserialize::<GetNodesInput>(&input.request.body)?;
+let arena = Bump::new();
+let txn = db.graph_env.read_txn().map_err(|e| GraphError::New(format!("Failed to start read transaction: {:?}", e)))?;
+    let node = G::new(&db, &txn, &arena)
+.n_from_type("MyNode")
+
+.filter_ref(|val, txn|{
+                if let Ok(val) = val {
+                    Ok(val
+                    .get_property("field")
+                    .map_or(false, |v| v.is_in(&data.fields)))
+                } else {
+                    Ok(false)
+                }
+            }).collect::<Result<Vec<_>, _>>()?;
+let response = json!({
+    "node": node.iter().map(|node| GetNodesNodeReturnType {
+        id: uuid_str(node.id(), &arena),
+        label: node.label(),
+        field: node.get_property("field"),
+    }).collect::<Vec<_>>()
+});
+txn.commit().map_err(|e| GraphError::New(format!("Failed to commit transaction: {:?}", e)))?;
+Ok(input.request.out_fmt.create_response(&response))
+}
+
+

--- a/hql-tests/tests/is_in/schema.hx
+++ b/hql-tests/tests/is_in/schema.hx
@@ -1,0 +1,32 @@
+// N::Doc {
+//     content: String
+// }
+//     
+// V::Embedding {
+//     chunk: String
+// }
+// 
+// N::Chunk {
+//     content: String
+// }
+// 
+// E::EmbeddingOf {
+//     From: Doc,
+//     To: Embedding, 
+//     Properties: {
+//     }
+// }
+
+// N::User {
+//     name: String,
+//     age: I32
+// }
+// 
+// E::Knows {
+//     From: User,
+//     To: User,
+//     Properties: {
+//         since: I32,
+//     }
+// }
+


### PR DESCRIPTION
## Summary

This PR integrates the fixes from PR #666 into the current `arena-implementation` branch. PR #666 originally fixed IS_IN validation and runtime handling for reserved properties, but the current implementation has diverged significantly from when that PR was created.

## Problem

**Analyzer Issue**: The type validator incorrectly grouped `IS_IN` with other boolean operations, expecting scalar arguments instead of arrays. This caused compilation errors for queries like `nodes::WHERE(_::{id}::IS_IN(node_ids))` when `node_ids` is `[ID]`.

**Runtime Issue**: The current implementation removed `filterable.rs` and its special handling for reserved properties (id, label, etc.). Reserved properties are now struct fields, not in the properties HashMap, so `get_property("id")` returns `None`.

**Root Cause**: 
1. IS_IN validation expects scalars instead of arrays
2. Reserved properties lost special handling during refactoring
3. Type mismatch between `Value::String` and `Value::Id` for ID operations

## Solution

### 1. Added Reserved Property Support
- Created `ReservedProp` enum for built-in properties: Id, Label, Version, FromNode, ToNode, Deleted, Level, Distance, Data
- Added `Step::ReservedPropertyAccess` variant to generate direct field access
- Reserved properties now return correct Value types (e.g., `Value::Id` for id field)

### 2. Updated Property Access Generator
- Modified `gen_property_access()` in `analyzer/utils.rs` to identify reserved vs user-defined properties
- Reserved properties use direct struct field access: `Value::Id(ID::from(val.id))`
- User-defined properties continue using `get_property()` HashMap lookup

### 3. Enhanced Boolean Operation Optimization
- Updated `WhereRef` Display implementation in `traversal_steps.rs` for reserved properties
- Generates optimized filter code with correct Value types
- Example: `Value::Id(ID::from(val.id)).is_in(&data.node_ids)`

### 4. Fixed IS_IN Validation
- Separated IS_IN from scalar boolean operations in `traversal_validation.rs`
- IS_IN now correctly expects `Type::Array(Box<Type::Scalar(ft)))` arguments
- Added `get_reserved_property_type()` helper for type-safe validation
- Updated Node/Edge/Vector validation to check reserved properties first

## Files Changed

- `helix-db/src/helixc/generator/traversal_steps.rs` - Added ReservedProp enum and Display logic
- `helix-db/src/helixc/analyzer/utils.rs` - Updated gen_property_access() 
- `helix-db/src/helixc/analyzer/methods/traversal_validation.rs` - Fixed IS_IN validation and reserved property checking
- `hql-tests/tests/is_in/` - Added test cases for IS_IN with reserved and user-defined properties

## Testing

Added comprehensive IS_IN tests:
```hql
QUERY GetNodes (fields: [String]) =>
    node <- N<MyNode>::WHERE(_::{field}::IS_IN(fields))
    RETURN node

QUERY GetNodesByID (node_ids: [ID]) =>
    node <- N<MyNode>::WHERE(_::{id}::IS_IN(node_ids))
    RETURN node
```

**Verified**:
- ✅ Queries compile successfully
- ✅ Correct code generation for reserved properties (direct field access)
- ✅ Correct code generation for user-defined properties (get_property)
- ✅ Type safety maintained for array operations

## Generated Code Example

For reserved property `id`:
```rust
.filter_ref(|val, txn|{
    if let Ok(val) = val {
        Ok(Value::Id(ID::from(val.id)).is_in(&data.node_ids))
    } else {
        Ok(false)
    }
})
```

For user-defined property `field`:
```rust
.filter_ref(|val, txn|{
    if let Ok(val) = val {
        Ok(val
        .get_property("field")
        .map_or(false, |v| v.is_in(&data.fields)))
    } else {
        Ok(false)
    }
})
```

## Impact

- IS_IN operations now work correctly with arrays at compile-time and runtime
- Reserved properties return proper Value types for IS_IN comparisons
- Queries like `WHERE(_::{id}::IS_IN(node_ids))` compile and execute without panics
- No breaking changes to existing functionality

Co-Authored-By: ishaksebsib <ishaksebsib@gmail.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-29 11:45:31 UTC

<h3>Greptile Summary</h3>


Fixes IS_IN operator validation and code generation for reserved properties by separating IS_IN from scalar boolean operations and introducing direct struct field access.

**Key Changes:**
- Separated IS_IN validation to correctly expect `Type::Array` arguments instead of scalars (traversal_validation.rs:798-834)
- Added `ReservedProp` enum and `Step::ReservedPropertyAccess` to distinguish reserved properties from user-defined properties
- Updated property access generator to return specialized steps for reserved properties like `id`, `label`, `version`, etc.
- Optimized WHERE clause code generation to use direct field access (`val.id`) for reserved properties instead of HashMap lookups

**Issues Found:**
- Inconsistent array validation for Edge reserved properties - missing the array unwrapping logic present in Node validation
- Inconsistent Value type generation for ID properties - regular property access generates String-based Values while WHERE optimizations generate `Value::Id`

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/helixc/analyzer/methods/traversal_validation.rs | 3/5 | Added `get_reserved_property_type()` helper and separated IS_IN validation from scalar boolean operations. Issue: inconsistent array validation for reserved properties in Edges validation (lines 947-960). |
| helix-db/src/helixc/analyzer/utils.rs | 5/5 | Updated `gen_property_access()` to return `Step::ReservedPropertyAccess` for reserved properties instead of treating them as regular properties. |
| helix-db/src/helixc/generator/traversal_steps.rs | 4/5 | Added `ReservedProp` enum and optimized code generation for reserved properties in WHERE clauses. Issue: inconsistent Value type handling for ID properties (lines 263, 455). |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Query as HQL Query
    participant Analyzer as traversal_validation
    participant PropAccess as gen_property_access
    participant Generator as WhereRef Display
    participant Runtime as Generated Code

    Query->>Analyzer: WHERE(_::{id}::IS_IN(node_ids))
    
    Note over Analyzer: Validate boolean operation
    Analyzer->>Analyzer: Check operation type
    
    alt IS_IN Operation (Line 798)
        Analyzer->>Analyzer: Expect Type::Array argument
        Analyzer->>Analyzer: Extract scalar element type
        Note over Analyzer: Property type = FieldType (e.g., Uuid)
    else Scalar Operations
        Analyzer->>Analyzer: Expect Type::Scalar argument
    end
    
    Analyzer->>Analyzer: Validate property access
    
    alt Reserved Property (e.g., id)
        Analyzer->>Analyzer: get_reserved_property_type()
        Note over Analyzer: Returns FieldType::Uuid for id
        Analyzer->>Analyzer: Compare with array element type
    else User-defined Property
        Analyzer->>Analyzer: Look up in schema fields
        Analyzer->>Analyzer: Compare field type
    end
    
    Query->>PropAccess: Generate property access for id
    PropAccess->>PropAccess: Recognize reserved property
    PropAccess-->>Query: Step::ReservedPropertyAccess(Id)
    
    Query->>Generator: Generate WHERE clause code
    
    alt Optimized Path (val.property.BoolOp)
        Generator->>Generator: Detect ReservedPropertyAccess + BoolOp
        Generator->>Generator: Generate direct field access
        Generator-->>Runtime: Value::Id(ID::from(val.id)).is_in(&data.node_ids)
    else Standard Path
        Generator->>Generator: Generate get_property call
        Generator-->>Runtime: val.get_property("field").map_or(false, |v| v.is_in(...))
    end
    
    Runtime->>Runtime: Execute filter at runtime
    Runtime-->>Query: Return filtered results
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->