### PR TITLE
Integrate PR #667: Add .id() method for borrowed ID support

### DIFF
--- a/helix-db/src/utils/id.rs
+++ b/helix-db/src/utils/id.rs
@@ -25,6 +25,10 @@ impl ID {
         self.0
     }
 
+    pub fn id(&self) -> u128 {
+        self.0
+    }
+
     pub fn stringify(&self) -> String {
         uuid::Uuid::from_u128(self.0).to_string()
     }

--- a/hql-tests/tests/add_e_borrowed_ids/config.hx.json
+++ b/hql-tests/tests/add_e_borrowed_ids/config.hx.json
@@ -1,0 +1,14 @@
+{
+    "vector_config": {
+        "m": 16,
+        "ef_construction": 128,
+        "ef_search": 768,
+        "db_max_size": 20
+    },
+    "graph_config": {
+        "secondary_indices": []
+    },
+    "db_max_size_gb": 20,
+    "mcp": false,
+    "bm25": false
+}

--- a/hql-tests/tests/add_e_borrowed_ids/helix.toml
+++ b/hql-tests/tests/add_e_borrowed_ids/helix.toml
@@ -1,0 +1,9 @@
+[project]
+name = "add_e_borrowed_ids"
+queries = "."
+
+[local.dev]
+port = 6969
+build_mode = "debug"
+
+[cloud]

--- a/hql-tests/tests/add_e_borrowed_ids/queries.hx
+++ b/hql-tests/tests/add_e_borrowed_ids/queries.hx
@@ -1,0 +1,5 @@
+QUERY AddEdges(edges: [{from_id: ID, to_id: ID, since: String}]) =>
+    FOR {from_id, to_id, since} IN edges {
+        AddE<Knows>({since: since})::From(from_id)::To(to_id)
+    }
+    RETURN "Edges added successfully"

--- a/hql-tests/tests/add_e_borrowed_ids/queries.rs
+++ b/hql-tests/tests/add_e_borrowed_ids/queries.rs
@@ -1,0 +1,182 @@
+
+// DEFAULT CODE
+// use helix_db::helix_engine::traversal_core::config::Config;
+
+// pub fn config() -> Option<Config> {
+//     None
+// }
+
+
+
+use bumpalo::Bump;
+use heed3::RoTxn;
+use helix_macros::{handler, tool_call, mcp_handler, migration};
+use helix_db::{
+    helix_engine::{
+        traversal_core::{
+            config::{Config, GraphConfig, VectorConfig},
+            ops::{
+                bm25::search_bm25::SearchBM25Adapter,
+                g::G,
+                in_::{in_::InAdapter, in_e::InEdgesAdapter, to_n::ToNAdapter, to_v::ToVAdapter},
+                out::{
+                    from_n::FromNAdapter, from_v::FromVAdapter, out::OutAdapter, out_e::OutEdgesAdapter,
+                },
+                source::{
+                    add_e::AddEAdapter,
+                    add_n::AddNAdapter,
+                    e_from_id::EFromIdAdapter,
+                    e_from_type::EFromTypeAdapter,
+                    n_from_id::NFromIdAdapter,
+                    n_from_index::NFromIndexAdapter,
+                    n_from_type::NFromTypeAdapter,
+                    v_from_id::VFromIdAdapter,
+                    v_from_type::VFromTypeAdapter
+                },
+                util::{
+                    dedup::DedupAdapter, drop::Drop, exist::Exist, filter_mut::FilterMut,
+                    filter_ref::FilterRefAdapter, map::MapAdapter, paths::{PathAlgorithm, ShortestPathAdapter},
+                    range::RangeAdapter, update::UpdateAdapter, order::OrderByAdapter,
+                    aggregate::AggregateAdapter, group_by::GroupByAdapter, count::CountAdapter,
+                },
+                vectors::{
+                    brute_force_search::BruteForceSearchVAdapter, insert::InsertVAdapter,
+                    search::SearchVAdapter,
+                },
+            },
+            traversal_value::TraversalValue,
+        },
+        types::GraphError,
+        vector_core::vector::HVector,
+    },
+    helix_gateway::{
+        embedding_providers::{EmbeddingModel, get_embedding_model},
+        router::router::{HandlerInput, IoContFn},
+        mcp::mcp::{MCPHandlerSubmission, MCPToolInput, MCPHandler}
+    },
+    node_matches, props, embed, embed_async,
+    field_addition_from_old_field, field_type_cast, field_addition_from_value,
+    protocol::{
+        response::Response,
+        value::{casting::{cast, CastType}, Value},
+        format::Format,
+    },
+    utils::{
+        count::Count,
+        id::{ID, uuid_str},
+        items::{Edge, Node},
+        properties::ImmutablePropertiesMap,
+    },
+};
+use sonic_rs::{Deserialize, Serialize, json};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Instant;
+use chrono::{DateTime, Utc};
+
+// Re-export scalar types for generated code
+type I8 = i8;
+type I16 = i16;
+type I32 = i32;
+type I64 = i64;
+type U8 = u8;
+type U16 = u16;
+type U32 = u32;
+type U64 = u64;
+type U128 = u128;
+type F32 = f32;
+type F64 = f64;
+    
+pub fn config() -> Option<Config> {
+return Some(Config {
+vector_config: Some(VectorConfig {
+m: Some(16),
+ef_construction: Some(128),
+ef_search: Some(768),
+}),
+graph_config: Some(GraphConfig {
+secondary_indices: Some(vec![]),
+}),
+db_max_size_gb: Some(10),
+mcp: Some(true),
+bm25: Some(true),
+schema: Some(r#"{
+  "schema": {
+    "nodes": [
+      {
+        "name": "Person",
+        "properties": {
+          "id": "ID",
+          "label": "String",
+          "name": "String"
+        }
+      }
+    ],
+    "vectors": [],
+    "edges": [
+      {
+        "name": "Knows",
+        "from": "Person",
+        "to": "Person",
+        "properties": {
+          "since": "String"
+        }
+      }
+    ]
+  },
+  "queries": [
+    {
+      "name": "AddEdges",
+      "parameters": {
+        "edges": "Array({to_id: IDsince: Stringfrom_id: ID})"
+      },
+      "returns": []
+    }
+  ]
+}"#.to_string()),
+embedding_model: Some("text-embedding-ada-002".to_string()),
+graphvis_node_label: None,
+})
+}
+
+pub struct Person {
+    pub name: String,
+}
+
+pub struct Knows {
+    pub from: Person,
+    pub to: Person,
+    pub since: String,
+}
+
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct AddEdgesInput {
+
+pub edges: Vec<edgesData>
+}
+#[derive(Serialize, Deserialize, Clone)]
+pub struct edgesData {
+    pub to_id: ID,
+    pub since: String,
+    pub from_id: ID,
+}
+#[handler]
+pub fn AddEdges (input: HandlerInput) -> Result<Response, GraphError> {
+let db = Arc::clone(&input.graph.storage);
+let data = input.request.in_fmt.deserialize::<AddEdgesInput>(&input.request.body)?;
+let arena = Bump::new();
+let mut txn = db.graph_env.write_txn().map_err(|e| GraphError::New(format!("Failed to start write transaction: {:?}", e)))?;
+    for edgesData { from_id, to_id, since } in &data.edges {
+    G::new_mut(&db, &arena, &mut txn)
+.add_edge("Knows", Some(ImmutablePropertiesMap::new(1, vec![("since", Value::from(since.clone()))].into_iter(), &arena)), from_id.id(), to_id.id(), false).collect_to_obj();
+}
+;
+let response = json!({
+    "data": "Edges added successfully"
+});
+txn.commit().map_err(|e| GraphError::New(format!("Failed to commit transaction: {:?}", e)))?;
+Ok(input.request.out_fmt.create_response(&response))
+}
+
+

--- a/hql-tests/tests/add_e_borrowed_ids/schema.hx
+++ b/hql-tests/tests/add_e_borrowed_ids/schema.hx
@@ -1,0 +1,11 @@
+N::Person {
+    name: String
+}
+
+E::Knows {
+    From: Person,
+    To: Person,
+    Properties: {
+        since: String
+    }
+}


### PR DESCRIPTION
## Summary

This PR integrates the fix from #667 into the arena-implementation branch. It adds an .id() method to the ID struct to resolve compilation errors when using AddE with borrowed IDs in FOR loops.

## Changes

- Added ID.id() method in helix-db/src/utils/id.rs returning u128 directly
- Added test case in hql-tests/tests/add_e_borrowed_ids/ validating the fix

## Technical Details

The helixc code generator consistently generates .id() calls to access ID values. Before this change, calling .id() on &ID (borrowed ID) would fail. This fix leverages Rust's auto-deref so both ID.id() and &ID.id() work seamlessly.

## Testing

✅ cargo check --workspace passes
✅ All 27 ID struct unit tests pass  
✅ New test case compiles successfully

Co-Authored-By: ishaksebsib

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-29 11:46:27 UTC

<h3>Greptile Summary</h3>


This PR fixes a compilation error where AddE queries with borrowed ID references in FOR loops failed because `&ID` didn't have an `.id()` method. The solution adds an `.id()` method to the ID struct that returns `u128`, leveraging Rust's auto-deref so both `ID.id()` and `&ID.id()` work seamlessly.

**Key Changes:**
- Added `pub fn id(&self) -> u128` method to ID struct in `helix-db/src/utils/id.rs:28-30`
- Method mirrors existing `.inner()` method but provides the interface expected by code generator
- Code generator in `helix-db/src/helixc/analyzer/utils.rs:100` generates `{name}.id()` calls for identifier references
- New test case validates the fix works for AddE operations with borrowed IDs from FOR loop iterations

**Technical Context:**
The helixc code generator's `gen_id_access_or_param` function consistently generates `.id()` calls to access ID values from identifiers. When iterating over arrays in FOR loops (like `FOR {from_id, to_id} IN edges`), the variables are borrowed references (`&ID`). Before this change, calling `.id()` on `&ID` would fail to compile. By adding the `.id()` method, Rust's auto-deref mechanism automatically handles both owned and borrowed cases.

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/utils/id.rs | 5/5 | Added `.id()` method to ID struct returning u128, enabling both owned and borrowed IDs to work with code generator |
| hql-tests/tests/add_e_borrowed_ids/queries.hx | 5/5 | Test query demonstrating FOR loop with borrowed IDs in AddE operation |
| hql-tests/tests/add_e_borrowed_ids/queries.rs | 5/5 | Generated code showing .id() method successfully called on borrowed ID references from FOR loop iteration |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as HQL Query
    participant Parser as HQL Parser
    participant Analyzer as Semantic Analyzer
    participant CodeGen as Code Generator
    participant ID as ID Struct
    
    User->>Parser: AddE query with FOR loop
    Note over User: FOR {from_id, to_id} IN edges<br/>AddE::From(from_id)::To(to_id)
    
    Parser->>Analyzer: Parse AddE with identifiers
    Analyzer->>Analyzer: Validate identifiers in scope
    Note over Analyzer: from_id: &ID (borrowed from iteration)
    
    Analyzer->>CodeGen: gen_id_access_or_param(from_id)
    Note over CodeGen: Generates: from_id.id()
    
    CodeGen->>ID: Call .id() on &ID
    Note over ID: Before: &ID had no .id() method<br/>Compiler error: "no method named id"
    
    ID-->>CodeGen: After: auto-deref to ID.id()
    Note over ID: Rust auto-deref: &ID -> ID<br/>Returns u128 from self.0
    
    CodeGen-->>Analyzer: GeneratedValue with u128
    Analyzer-->>User: Compiled query code
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->