### PR TITLE
updating versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "helix-cli"
-version = "2.0.6"
+version = "2.1.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "helix-db"
-version = "2.0.1"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/helix-cli/Cargo.toml
+++ b/helix-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-cli"
-version = "2.0.6"
+version = "2.1.0"
 edition = "2024"
 
 [dependencies]

--- a/helix-db/Cargo.toml
+++ b/helix-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-db"
-version = "2.0.1"
+version = "1.1.0"
 edition = "2024"
 description = "HelixDB is a powerful, open-source, graph-vector database built in Rust for intelligent data storage for RAG and AI."
 license = "AGPL-3.0"


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-07 07:51:24 UTC

<h3>Greptile Summary</h3>


This PR updates version numbers for both `helix-cli` and `helix-db` packages. The `helix-cli` version correctly increments from 2.0.6 → 2.1.0, indicating a minor release. However, the `helix-db` version changes from 2.0.1 → 1.1.0, which is a version downgrade that violates semantic versioning principles.

**Key Issues:**
- `helix-db` version downgrade (2.0.1 → 1.1.0) breaks semantic versioning and will cause issues with package managers and dependency resolution
- This could prevent users from updating to the latest version if they have 2.0.1 installed

**Minor notes:**
- `Cargo.lock` is properly synchronized with the manifest changes
- `helix-cli` version bump follows correct semantic versioning

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/Cargo.toml | 0/5 | Version downgraded from 2.0.1 → 1.1.0, violating semantic versioning |
| helix-cli/Cargo.toml | 5/5 | Version updated from 2.0.6 → 2.1.0, follows semantic versioning correctly |
| Cargo.lock | 3/5 | Lockfile properly synchronized with Cargo.toml changes, but inherits helix-db versioning issue |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant CLI as helix-cli/Cargo.toml
    participant DB as helix-db/Cargo.toml
    participant Lock as Cargo.lock
    
    Dev->>CLI: Update version 2.0.6 → 2.1.0
    Note over CLI: Minor version bump (correct)
    
    Dev->>DB: Update version 2.0.1 → 1.1.0
    Note over DB: ⚠️ Version downgrade!
    
    Dev->>Lock: Run cargo update
    Lock->>CLI: Read new version (2.1.0)
    Lock->>DB: Read new version (1.1.0)
    Lock-->>Lock: Synchronize dependencies
    Note over Lock: Properly synced but<br/>inherits versioning issue
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->