### PR TITLE
fix (core): fixing builtins

### DIFF
--- a/.github/workflows/db_tests.yml
+++ b/.github/workflows/db_tests.yml
@@ -33,3 +33,8 @@ jobs:
       run: | 
         cd helix-db
         cargo test --release --lib -- --skip concurrency_tests
+
+    - name: Run dev instance tests
+      run: | 
+        cd helix-db
+        cargo test --release --lib --features dev-instance -- --skip concurrency_tests

--- a/helix-db/src/helix_engine/storage_core/graph_visualization.rs
+++ b/helix-db/src/helix_engine/storage_core/graph_visualization.rs
@@ -1,0 +1,299 @@
+use crate::{
+    debug_println,
+    helix_engine::{storage_core::HelixGraphStorage, types::GraphError},
+    utils::items::Node,
+};
+use heed3::{types::*, RoIter, RoTxn};
+use sonic_rs::{json, JsonValueMutTrait, Value as JsonValue};
+use std::{
+    cmp::Ordering,
+    collections::{BinaryHeap, HashMap},
+    sync::Arc,
+};
+
+/// Set of functions to access the nodes and edges stored to export to json
+pub trait GraphVisualization {
+    /// Serializes nodes and edges to JSON for graph visualization.
+    fn nodes_edges_to_json(
+        &self,
+        txn: &RoTxn,
+        k: Option<usize>,
+        node_prop: Option<String>,
+    ) -> Result<String, GraphError>;
+
+    /// Retrieves database statistics in JSON format.
+    fn get_db_stats_json(&self, txn: &RoTxn) -> Result<String, GraphError>;
+}
+
+impl GraphVisualization for HelixGraphStorage {
+    fn nodes_edges_to_json(
+        &self,
+        txn: &RoTxn,
+        k: Option<usize>,
+        node_prop: Option<String>,
+    ) -> Result<String, GraphError> {
+        let k = k.unwrap_or(200);
+        if k > 300 {
+            return Err(GraphError::New(
+                "cannot not visualize more than 300 nodes!".to_string(),
+            ));
+        }
+
+        if self.nodes_db.is_empty(txn)? || self.edges_db.is_empty(txn)? {
+            return Err(GraphError::New(
+                "edges or nodes db is empty!".to_string(),
+            ));
+        }
+
+        let top_nodes = self.get_nodes_by_cardinality(txn, k)?;
+
+        let ret_json = self.cards_to_json(txn, k, top_nodes, node_prop)?;
+        sonic_rs::to_string(&ret_json).map_err(|e| GraphError::New(e.to_string()))
+    }
+
+    fn get_db_stats_json(&self, txn: &RoTxn) -> Result<String, GraphError> {
+        let result = json!({
+            "num_nodes":   self.nodes_db.len(txn).unwrap_or(0),
+            "num_edges":   self.edges_db.len(txn).unwrap_or(0),
+            "num_vectors": self.vectors.vectors_db.len(txn).unwrap_or(0),
+        });
+        debug_println!("db stats json: {:?}", result);
+
+        sonic_rs::to_string(&result).map_err(|e| GraphError::New(e.to_string()))
+    }
+}
+
+/// Implementing the helper functions needed to get the data for graph visualization
+impl HelixGraphStorage {
+    /// Get the top k nodes and all of the edges associated with them by checking their
+    /// cardinalities (total number of in and out edges)
+    #[allow(clippy::type_complexity)]
+    fn get_nodes_by_cardinality(
+        &self,
+        txn: &RoTxn,
+        k: usize,
+    ) -> Result<Vec<(u128, Vec<(u128, u128, u128)>, Vec<(u128, u128, u128)>)>, GraphError> {
+        let node_count = self.nodes_db.len(txn)?;
+
+        type EdgeID = u128;
+        type ToNodeId = u128;
+        type FromNodeId = u128;
+
+        struct EdgeCount {
+            node_id: u128,
+            edges_count: usize,
+            out_edges: Vec<(EdgeID, FromNodeId, ToNodeId)>,
+            in_edges: Vec<(EdgeID, FromNodeId, ToNodeId)>,
+        }
+
+        impl PartialEq for EdgeCount {
+            fn eq(&self, other: &Self) -> bool {
+                self.edges_count == other.edges_count
+            }
+        }
+        impl Eq for EdgeCount {}
+        impl PartialOrd for EdgeCount {
+            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+        impl Ord for EdgeCount {
+            fn cmp(&self, other: &Self) -> Ordering {
+                self.edges_count.cmp(&other.edges_count)
+            }
+        }
+
+        let db = Arc::new(self);
+        let out_db = Arc::clone(&db);
+        let in_db = Arc::clone(&db);
+
+        #[derive(Default)]
+        struct Edges<'a> {
+            edge_count: usize,
+            out_edges: Option<
+                RoIter<
+                    'a,
+                    Bytes,
+                    LazyDecode<Bytes>,
+                    heed3::iteration_method::MoveOnCurrentKeyDuplicates,
+                >,
+            >,
+            in_edges: Option<
+                RoIter<
+                    'a,
+                    Bytes,
+                    LazyDecode<Bytes>,
+                    heed3::iteration_method::MoveOnCurrentKeyDuplicates,
+                >,
+            >,
+        }
+
+        let mut edge_counts: HashMap<u128, Edges> = HashMap::with_capacity(node_count as usize);
+        let mut ordered_edge_counts: BinaryHeap<EdgeCount> =
+            BinaryHeap::with_capacity(node_count as usize);
+
+        // out edges - iterate through nodes by getting each unique node ID from out_edges_db
+        let out_node_key_iter = out_db
+            .out_edges_db
+            .lazily_decode_data()
+            .iter(txn)
+            .unwrap();
+        for data in out_node_key_iter {
+            match data {
+                Ok((key, _)) => {
+                    let node_id = &key[0..16];
+                    let edges = out_db
+                        .out_edges_db
+                        .lazily_decode_data()
+                        .get_duplicates(txn, key)
+                        .unwrap();
+
+                    let edges_count = edges.iter().count();
+
+                    let edge_count = edge_counts
+                        .entry(u128::from_be_bytes(node_id.try_into().unwrap()))
+                        .or_default();
+                    edge_count.edge_count += edges_count;
+                    edge_count.out_edges = edges;
+                }
+                Err(_e) => {
+                    debug_println!("Error in out_node_key_iter: {:?}", _e);
+                }
+            }
+        }
+
+        // in edges
+        let in_node_key_iter = in_db.in_edges_db.lazily_decode_data().iter(txn).unwrap();
+        for data in in_node_key_iter {
+            match data {
+                Ok((key, _)) => {
+                    let node_id = &key[0..16];
+                    let edges = in_db
+                        .in_edges_db
+                        .lazily_decode_data()
+                        .get_duplicates(txn, key)
+                        .unwrap();
+                    let edges_count = edges.iter().count();
+
+                    let edge_count = edge_counts
+                        .entry(u128::from_be_bytes(node_id.try_into().unwrap()))
+                        .or_default();
+                    edge_count.edge_count += edges_count;
+                    edge_count.in_edges = edges;
+                }
+                Err(_e) => {
+                    debug_println!("Error in in_node_key_iter: {:?}", _e);
+                }
+            }
+        }
+
+        // Decode edges and extract edge id and other node id
+        for (node_id, edges_count) in edge_counts.into_iter() {
+            let out_edges = match edges_count.out_edges {
+                Some(out_edges_iter) => out_edges_iter
+                    .map(|result| {
+                        let (key, value) = result.unwrap();
+                        let from_node = u128::from_be_bytes(key[0..16].try_into().unwrap());
+                        let (edge_id, to_node) =
+                            Self::unpack_adj_edge_data(value.decode().unwrap()).unwrap();
+                        (edge_id, from_node, to_node)
+                    })
+                    .collect::<Vec<(EdgeID, FromNodeId, ToNodeId)>>(),
+                None => vec![],
+            };
+            let in_edges = match edges_count.in_edges {
+                Some(in_edges_iter) => in_edges_iter
+                    .map(|result| {
+                        let (key, value) = result.unwrap();
+                        let to_node = u128::from_be_bytes(key[0..16].try_into().unwrap());
+                        let (edge_id, from_node) =
+                            Self::unpack_adj_edge_data(value.decode().unwrap()).unwrap();
+                        (edge_id, from_node, to_node)
+                    })
+                    .collect::<Vec<(EdgeID, FromNodeId, ToNodeId)>>(),
+                None => vec![],
+            };
+
+            ordered_edge_counts.push(EdgeCount {
+                node_id,
+                edges_count: edges_count.edge_count,
+                out_edges,
+                in_edges,
+            });
+        }
+
+        let mut top_nodes = Vec::with_capacity(k);
+        while let Some(edges_count) = ordered_edge_counts.pop() {
+            top_nodes.push((
+                edges_count.node_id,
+                edges_count.out_edges,
+                edges_count.in_edges,
+            ));
+            if top_nodes.len() >= k {
+                break;
+            }
+        }
+
+        Ok(top_nodes)
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn cards_to_json(
+        &self,
+        txn: &RoTxn,
+        k: usize,
+        top_nodes: Vec<(u128, Vec<(u128, u128, u128)>, Vec<(u128, u128, u128)>)>,
+        node_prop: Option<String>,
+    ) -> Result<JsonValue, GraphError> {
+        let mut nodes = Vec::with_capacity(k);
+        let mut edges = Vec::new();
+
+        // Create temporary arena for node deserialization
+        let arena = bumpalo::Bump::new();
+
+        top_nodes
+            .iter()
+            .try_for_each(|(id, out_edges, _in_edges)| {
+                let mut json_node = json!({ "id": id.to_string(), "title": id.to_string() });
+                if let Some(prop) = &node_prop {
+                    // Get node data
+                    if let Some(node_data) = self.nodes_db.get(txn, id)? {
+                        let node = Node::from_bincode_bytes(*id, node_data, &arena)?;
+                        if let Some(props) = node.properties
+                            && let Some(prop_value) = props.get(prop) {
+                                json_node
+                                    .as_object_mut()
+                                    .ok_or_else(|| {
+                                        GraphError::New("invalid JSON object".to_string())
+                                    })?
+                                    .insert(
+                                        "label",
+                                        sonic_rs::to_value(&prop_value.inner_stringify())
+                                            .unwrap_or_else(|_| sonic_rs::Value::from("")),
+                                    );
+                            }
+                    }
+                }
+
+                nodes.push(json_node);
+                out_edges
+                    .iter()
+                    .for_each(|(edge_id, from_node_id, to_node_id)| {
+                        edges.push(json!({
+                            "from": from_node_id.to_string(),
+                            "to": to_node_id.to_string(),
+                            "title": edge_id.to_string(),
+                        }));
+                    });
+
+                Ok::<(), GraphError>(())
+            })?;
+
+        let result = json!({
+            "nodes": nodes,
+            "edges": edges,
+        });
+
+        Ok(result)
+    }
+}

--- a/helix-db/src/helix_engine/storage_core/mod.rs
+++ b/helix-db/src/helix_engine/storage_core/mod.rs
@@ -1,3 +1,4 @@
+pub mod graph_visualization;
 pub mod metadata;
 pub mod storage_methods;
 pub mod storage_migration;

--- a/helix-db/src/helix_gateway/builtin/all_nodes_and_edges.rs
+++ b/helix-db/src/helix_gateway/builtin/all_nodes_and_edges.rs
@@ -9,7 +9,6 @@ use tracing::info;
 
 use crate::helix_engine::storage_core::graph_visualization::GraphVisualization;
 use crate::helix_engine::types::GraphError;
-use crate::helix_engine::vector_core::hnsw::HNSW;
 use crate::helix_gateway::gateway::AppState;
 use crate::helix_gateway::router::router::{Handler, HandlerInput, HandlerSubmission};
 use crate::protocol::{self, request::RequestType};
@@ -68,6 +67,7 @@ pub async fn nodes_edges_handler(
 pub fn nodes_edges_inner(input: HandlerInput) -> Result<protocol::Response, GraphError> {
     let db = Arc::clone(&input.graph.storage);
     let txn = db.graph_env.read_txn().map_err(GraphError::from)?;
+    let arena = bumpalo::Bump::new();
 
     let (limit, node_label) = if !input.request.body.is_empty() {
         match sonic_rs::from_slice::<sonic_rs::Value>(&input.request.body) {
@@ -90,14 +90,14 @@ pub fn nodes_edges_inner(input: HandlerInput) -> Result<protocol::Response, Grap
     let json_result = if limit.is_some() {
         db.nodes_edges_to_json(&txn, limit, node_label)?
     } else {
-        get_all_nodes_edges_json(&db, &txn, node_label)?
+        get_all_nodes_edges_json(&db, &txn, node_label, &arena)?
     };
 
     let db_stats = db.get_db_stats_json(&txn)?;
 
     let vectors_result = db
         .vectors
-        .get_all_vectors(&txn, None)
+        .get_all_vectors(&txn, None, &arena)
         .map(|vecs| {
             let vectors_json: Vec<sonic_rs::Value> = vecs
                 .iter()
@@ -128,6 +128,7 @@ fn get_all_nodes_edges_json(
     db: &Arc<crate::helix_engine::storage_core::HelixGraphStorage>,
     txn: &RoTxn,
     node_label: Option<String>,
+    arena: &bumpalo::Bump,
 ) -> Result<String, GraphError> {
     use sonic_rs::json;
 
@@ -144,14 +145,13 @@ fn get_all_nodes_edges_json(
         });
 
         if let Some(prop) = &node_label {
-            let node = Node::decode_node(value, id)?;
-            json_node["label"] = json!(node.label());
-            if let Some(props) = node.properties {
-                if let Some(prop_value) = props.get(prop) {
+            let node = Node::from_bincode_bytes(id, value, arena)?;
+            json_node["label"] = json!(node.label);
+            if let Some(props) = node.properties
+                && let Some(prop_value) = props.get(prop) {
                     json_node["label"] = sonic_rs::to_value(&prop_value.inner_stringify())
                         .unwrap_or_else(|_| sonic_rs::Value::from(""));
                 }
-            }
         }
         nodes.push(json_node);
     }
@@ -161,7 +161,7 @@ fn get_all_nodes_edges_json(
     let edge_iter = db.edges_db.iter(txn)?;
     for result in edge_iter {
         let (id, value) = result?;
-        let edge = Edge::decode_edge(value, id)?;
+        let edge = Edge::from_bincode_bytes(id, value, arena)?;
         let id_str = ID::from(id).stringify();
 
         edges.push(json!({
@@ -192,7 +192,6 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
     use axum::body::Bytes;
-    use crate::helix_engine::traversal_core::traversal_value::Traversable;
     use crate::{
         helix_engine::{
             storage_core::version_info::VersionInfo,
@@ -202,13 +201,14 @@ mod tests {
                 ops::{
                     g::G,
                     source::{
-                        add_e::{AddEAdapter, EdgeType},
+                        add_e::AddEAdapter,
                         add_n::AddNAdapter,
                     },
                 },
             },
         },
         protocol::{request::Request, request::RequestType, Format},
+        helixc::generator::traversal_steps::EdgeType,
     };
 
     fn setup_test_engine() -> (HelixGraphEngine, TempDir) {
@@ -253,22 +253,38 @@ mod tests {
     }
 
     #[test]
-    fn test_nodes_edges_with_data() {
+    fn test_nodes_edges_with_data() -> Result<(), Box<dyn std::error::Error>> {
         use crate::protocol::value::Value;
+        use crate::utils::properties::ImmutablePropertiesMap;
 
         let (engine, _temp_dir) = setup_test_engine();
         let mut txn = engine.storage.graph_env.write_txn().unwrap();
+        let arena = bumpalo::Bump::new();
 
-        let node1 = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-            .add_n("person", Some(vec![("name".to_string(), Value::String("Alice".to_string()))]), None)
+        let props1 = vec![("name", Value::String("Alice".to_string()))];
+        let props_map1 = ImmutablePropertiesMap::new(
+            props1.len(),
+            props1.iter().map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
+            &arena,
+        );
+
+        let node1 = G::new_mut(&engine.storage, &arena, &mut txn)
+            .add_n(arena.alloc_str("person"), Some(props_map1), None)
             .collect_to_obj()?;
 
-        let node2 = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-            .add_n("person", Some(vec![("name".to_string(), Value::String("Bob".to_string()))]), None)
+        let props2 = vec![("name", Value::String("Bob".to_string()))];
+        let props_map2 = ImmutablePropertiesMap::new(
+            props2.len(),
+            props2.iter().map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
+            &arena,
+        );
+
+        let node2 = G::new_mut(&engine.storage, &arena, &mut txn)
+            .add_n(arena.alloc_str("person"), Some(props_map2), None)
             .collect_to_obj()?;
 
-        let _edge = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-            .add_e("knows", None, node1.id(), node2.id(), false, EdgeType::Node)
+        let _edge = G::new_mut(&engine.storage, &arena, &mut txn)
+            .add_edge(arena.alloc_str("knows"), None, node1.id(), node2.id(), false)
             .collect_to_obj()?;
 
         txn.commit().unwrap();
@@ -294,27 +310,37 @@ mod tests {
         let body_str = String::from_utf8(response.body).unwrap();
         assert!(body_str.contains("\"nodes\""));
         assert!(body_str.contains("\"edges\""));
+        Ok(())
     }
 
     #[test]
-    fn test_nodes_edges_with_limit() {
+    fn test_nodes_edges_with_limit() -> Result<(), Box<dyn std::error::Error>> {
         use crate::protocol::value::Value;
+        use crate::utils::properties::ImmutablePropertiesMap;
 
         let (engine, _temp_dir) = setup_test_engine();
         let mut txn = engine.storage.graph_env.write_txn().unwrap();
+        let arena = bumpalo::Bump::new();
 
         let mut nodes = Vec::new();
         for i in 0..10 {
-            let node = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-                .add_n("person", Some(vec![("index".to_string(), Value::I64(i))]), None)
+            let props = vec![("index", Value::I64(i))];
+            let props_map = ImmutablePropertiesMap::new(
+                props.len(),
+                props.iter().map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
+                &arena,
+            );
+
+            let node = G::new_mut(&engine.storage, &arena, &mut txn)
+                .add_n(arena.alloc_str("person"), Some(props_map), None)
                 .collect_to_obj()?;
             nodes.push(node);
         }
 
         // Add some edges to satisfy the nodes_edges_to_json method
         for i in 0..5 {
-            let _edge = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-                .add_e("connects", None, nodes[i].id(), nodes[i+1].id(), false, EdgeType::Node)
+            let _edge = G::new_mut(&engine.storage, &arena, &mut txn)
+                .add_edge(arena.alloc_str("connects"), None, nodes[i].id(), nodes[i+1].id(), false)
                 .collect_to_obj()?;
         }
 
@@ -340,17 +366,27 @@ mod tests {
             eprintln!("Error in test_nodes_edges_with_limit: {:?}", e);
         }
         assert!(result.is_ok());
+        Ok(())
     }
 
     #[test]
-    fn test_nodes_edges_with_node_label() {
+    fn test_nodes_edges_with_node_label() -> Result<(), Box<dyn std::error::Error>> {
         use crate::protocol::value::Value;
+        use crate::utils::properties::ImmutablePropertiesMap;
 
         let (engine, _temp_dir) = setup_test_engine();
         let mut txn = engine.storage.graph_env.write_txn().unwrap();
+        let arena = bumpalo::Bump::new();
 
-        let _node = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-            .add_n("person", Some(vec![("name".to_string(), Value::String("Test".to_string()))]), None)
+        let props = vec![("name", Value::String("Test".to_string()))];
+        let props_map = ImmutablePropertiesMap::new(
+            props.len(),
+            props.iter().map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
+            &arena,
+        );
+
+        let _node = G::new_mut(&engine.storage, &arena, &mut txn)
+            .add_n(arena.alloc_str("person"), Some(props_map), None)
             .collect_to_obj()?;
 
         txn.commit().unwrap();
@@ -372,6 +408,7 @@ mod tests {
 
         let result = nodes_edges_inner(input);
         assert!(result.is_ok());
+        Ok(())
     }
 
     #[test]

--- a/helix-db/src/helix_gateway/builtin/node_by_id.rs
+++ b/helix-db/src/helix_gateway/builtin/node_by_id.rs
@@ -54,6 +54,7 @@ pub async fn node_details_handler(
 pub fn node_details_inner(input: HandlerInput) -> Result<protocol::Response, GraphError> {
     let db = Arc::clone(&input.graph.storage);
     let txn = db.graph_env.read_txn().map_err(GraphError::from)?;
+    let arena = bumpalo::Bump::new();
 
     let node_id_str = if !input.request.body.is_empty() {
         match sonic_rs::from_slice::<sonic_rs::Value>(&input.request.body) {
@@ -81,18 +82,18 @@ pub fn node_details_inner(input: HandlerInput) -> Result<protocol::Response, Gra
         },
     };
 
-    let result = match db.get_node(&txn, &node_id) {
+    let result = match db.get_node(&txn, &node_id, &arena) {
         Ok(node) => {
             let id_str = ID::from(node_id).stringify();
 
             let mut node_json = json!({
                 "id": id_str.clone(),
-                "label": node.label(),
+                "label": node.label,
                 "title": id_str
             });
 
             if let Some(properties) = &node.properties {
-                for (key, value) in properties {
+                for (key, value) in properties.iter() {
                     node_json[key] = sonic_rs::to_value(&value.inner_stringify())
                         .unwrap_or_else(|_| sonic_rs::Value::from(""));
                 }
@@ -129,7 +130,6 @@ mod tests {
     use std::sync::Arc;
     use tempfile::TempDir;
     use axum::body::Bytes;
-    use crate::helix_engine::traversal_core::traversal_value::Traversable;
     use crate::{
         helix_engine::{
             storage_core::version_info::VersionInfo,
@@ -160,12 +160,22 @@ mod tests {
     }
 
     #[test]
-    fn test_node_details_found() {
+    fn test_node_details_found() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::utils::properties::ImmutablePropertiesMap;
+
         let (engine, _temp_dir) = setup_test_engine();
         let mut txn = engine.storage.graph_env.write_txn().unwrap();
+        let arena = bumpalo::Bump::new();
 
-        let node = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-            .add_n("person", Some(vec![("name".to_string(), Value::String("Alice".to_string()))]), None)
+        let props = vec![("name", Value::String("Alice".to_string()))];
+        let props_map = ImmutablePropertiesMap::new(
+            props.len(),
+            props.iter().map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
+            &arena,
+        );
+
+        let node = G::new_mut(&engine.storage, &arena, &mut txn)
+            .add_n(arena.alloc_str("person"), Some(props_map), None)
             .collect_to_obj()?;
 
         txn.commit().unwrap();
@@ -193,6 +203,7 @@ mod tests {
         let response = result.unwrap();
         let body_str = String::from_utf8(response.body).unwrap();
         assert!(body_str.contains("\"found\":true"));
+        Ok(())
     }
 
     #[test]
@@ -271,15 +282,25 @@ mod tests {
     }
 
     #[test]
-    fn test_node_details_with_properties() {
+    fn test_node_details_with_properties() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::utils::properties::ImmutablePropertiesMap;
+
         let (engine, _temp_dir) = setup_test_engine();
         let mut txn = engine.storage.graph_env.write_txn().unwrap();
+        let arena = bumpalo::Bump::new();
 
-        let node = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-            .add_n("person", Some(vec![
-                ("name".to_string(), Value::String("Alice".to_string())),
-                ("age".to_string(), Value::I64(30)),
-            ]), None)
+        let props = vec![
+            ("name", Value::String("Alice".to_string())),
+            ("age", Value::I64(30)),
+        ];
+        let props_map = ImmutablePropertiesMap::new(
+            props.len(),
+            props.iter().map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
+            &arena,
+        );
+
+        let node = G::new_mut(&engine.storage, &arena, &mut txn)
+            .add_n(arena.alloc_str("person"), Some(props_map), None)
             .collect_to_obj()?;
 
         txn.commit().unwrap();
@@ -308,5 +329,6 @@ mod tests {
         let body_str = String::from_utf8(response.body).unwrap();
         assert!(body_str.contains("Alice"));
         assert!(body_str.contains("30"));
+        Ok(())
     }
 }

--- a/helix-db/src/helix_gateway/builtin/nodes_by_label.rs
+++ b/helix-db/src/helix_gateway/builtin/nodes_by_label.rs
@@ -56,6 +56,7 @@ pub async fn nodes_by_label_handler(
 pub fn nodes_by_label_inner(input: HandlerInput) -> Result<protocol::Response, GraphError> {
     let db = Arc::clone(&input.graph.storage);
     let txn = db.graph_env.read_txn().map_err(GraphError::from)?;
+    let arena = bumpalo::Bump::new();
 
     let (label, limit) = if !input.request.body.is_empty() {
         match sonic_rs::from_slice::<sonic_rs::Value>(&input.request.body) {
@@ -83,20 +84,20 @@ pub fn nodes_by_label_inner(input: HandlerInput) -> Result<protocol::Response, G
 
     for result in db.nodes_db.iter(&txn)? {
         let (id, node_data) = result?;
-        match Node::decode_node(node_data, id) {
+        match Node::from_bincode_bytes(id, node_data, &arena) {
             Ok(node) => {
-                if node.label() == label {
+                if node.label == label {
                     let id_str = ID::from(id).stringify();
 
                     let mut node_json = json!({
                         "id": id_str.clone(),
-                        "label": node.label(),
+                        "label": node.label,
                         "title": id_str
                     });
 
                     // Add node properties
                     if let Some(properties) = &node.properties {
-                        for (key, value) in properties {
+                        for (key, value) in properties.iter() {
                             node_json[key] = sonic_rs::to_value(&value.inner_stringify())
                                 .unwrap_or_else(|_| sonic_rs::Value::from(""));
                         }
@@ -105,11 +106,10 @@ pub fn nodes_by_label_inner(input: HandlerInput) -> Result<protocol::Response, G
                     nodes_json.push(node_json);
                     count += 1;
 
-                    if let Some(limit_count) = limit {
-                        if count >= limit_count {
+                    if let Some(limit_count) = limit
+                        && count >= limit_count {
                             break;
                         }
-                    }
                 }
             }
             Err(_) => continue,
@@ -168,16 +168,33 @@ mod tests {
     }
 
     #[test]
-    fn test_nodes_by_label_found() {
+    fn test_nodes_by_label_found() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::utils::properties::ImmutablePropertiesMap;
+
         let (engine, _temp_dir) = setup_test_engine();
         let mut txn = engine.storage.graph_env.write_txn().unwrap();
+        let arena = bumpalo::Bump::new();
 
-        let _node1 = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-            .add_n("person", Some(vec![("name".to_string(), Value::String("Alice".to_string()))]), None)
+        let props1 = vec![("name", Value::String("Alice".to_string()))];
+        let props_map1 = ImmutablePropertiesMap::new(
+            props1.len(),
+            props1.iter().map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
+            &arena,
+        );
+
+        let _node1 = G::new_mut(&engine.storage, &arena, &mut txn)
+            .add_n(arena.alloc_str("person"), Some(props_map1), None)
             .collect_to_obj()?;
 
-        let _node2 = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-            .add_n("person", Some(vec![("name".to_string(), Value::String("Bob".to_string()))]), None)
+        let props2 = vec![("name", Value::String("Bob".to_string()))];
+        let props_map2 = ImmutablePropertiesMap::new(
+            props2.len(),
+            props2.iter().map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
+            &arena,
+        );
+
+        let _node2 = G::new_mut(&engine.storage, &arena, &mut txn)
+            .add_n(arena.alloc_str("person"), Some(props_map2), None)
             .collect_to_obj()?;
 
         txn.commit().unwrap();
@@ -204,16 +221,27 @@ mod tests {
         let response = result.unwrap();
         let body_str = String::from_utf8(response.body).unwrap();
         assert!(body_str.contains("\"count\":2"));
+        Ok(())
     }
 
     #[test]
-    fn test_nodes_by_label_with_limit() {
+    fn test_nodes_by_label_with_limit() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::utils::properties::ImmutablePropertiesMap;
+
         let (engine, _temp_dir) = setup_test_engine();
         let mut txn = engine.storage.graph_env.write_txn().unwrap();
+        let arena = bumpalo::Bump::new();
 
         for i in 0..10 {
-            let _node = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-                .add_n("person", Some(vec![("index".to_string(), Value::I64(i))]), None)
+            let props = vec![("index", Value::I64(i))];
+            let props_map = ImmutablePropertiesMap::new(
+                props.len(),
+                props.iter().map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
+                &arena,
+            );
+
+            let _node = G::new_mut(&engine.storage, &arena, &mut txn)
+                .add_n(arena.alloc_str("person"), Some(props_map), None)
                 .collect_to_obj()?;
         }
 
@@ -241,6 +269,7 @@ mod tests {
         let response = result.unwrap();
         let body_str = String::from_utf8(response.body).unwrap();
         assert!(body_str.contains("\"count\":5"));
+        Ok(())
     }
 
     #[test]
@@ -294,16 +323,17 @@ mod tests {
     }
 
     #[test]
-    fn test_nodes_by_label_multiple_labels() {
+    fn test_nodes_by_label_multiple_labels() -> Result<(), Box<dyn std::error::Error>> {
         let (engine, _temp_dir) = setup_test_engine();
         let mut txn = engine.storage.graph_env.write_txn().unwrap();
+        let arena = bumpalo::Bump::new();
 
-        let _person = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-            .add_n("person", None, None)
+        let _person = G::new_mut(&engine.storage, &arena, &mut txn)
+            .add_n(arena.alloc_str("person"), None, None)
             .collect_to_obj()?;
 
-        let _company = G::new_mut(Arc::clone(&engine.storage), &mut txn)
-            .add_n("company", None, None)
+        let _company = G::new_mut(&engine.storage, &arena, &mut txn)
+            .add_n(arena.alloc_str("company"), None, None)
             .collect_to_obj()?;
 
         txn.commit().unwrap();
@@ -330,5 +360,6 @@ mod tests {
         let response = result.unwrap();
         let body_str = String::from_utf8(response.body).unwrap();
         assert!(body_str.contains("\"count\":1"));
+        Ok(())
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR updates builtin handler functions to use arena-based memory allocation for deserializing nodes and edges, improving memory management and consistency across the codebase.

## Key Changes

- **Arena allocation pattern**: All builtin handlers (`all_nodes_and_edges`, `node_by_id`, `node_connections`, `nodes_by_label`) now create a `bumpalo::Bump` arena and pass it to deserialization methods
- **API migration**: Replaced `Node::decode_node()` and `Edge::decode_edge()` with `Node::from_bincode_bytes()` and `Edge::from_bincode_bytes()` which require an arena parameter
- **Direct field access**: Changed from method calls (`node.label()`) to direct field access (`node.label`) since `Node` and `Edge` now have public `&'arena str` fields
- **Properties iteration**: Updated from `for (k, v) in properties` to `for (k, v) in properties.iter()` to work with the immutable properties map
- **Test updates**: All tests updated to use arena allocators and `ImmutablePropertiesMap` for property creation
- **Test method signatures**: Changed from `.add_e()` to `.add_edge()` and adjusted `G::new_mut()` call patterns to pass arena before txn
- **New functionality**: Added `VectorCore::get_all_vectors()` method and `graph_visualization` module with proper arena handling
- **CI enhancement**: Added dev-instance feature testing to GitHub Actions workflow

## Code Style Improvements

- Simplified nested conditionals using `let` chains (e.g., `if let Some(props) = node.properties && let Some(prop_value) = props.get(prop)`)
- Removed unnecessary `Arc::clone()` patterns in tests
- Added proper error propagation with `Result<(), Box<dyn std::error::Error>>` return types in tests

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/helix_engine/storage_core/graph_visualization.rs | 5/5 | New module implementing graph visualization with proper arena allocation for node/edge data |
| helix-db/src/helix_gateway/builtin/all_nodes_and_edges.rs | 5/5 | Updated to use arena-based deserialization, replaced Arc::clone patterns, simplified conditionals, and updated test signatures |
| helix-db/src/helix_gateway/builtin/node_by_id.rs | 5/5 | Updated to use arena-based deserialization, changed node.label() to node.label, and updated test return types |
| helix-db/src/helix_gateway/builtin/node_connections.rs | 5/5 | Updated to use arena-based deserialization, simplified nested conditionals, and updated test signatures |
| helix-db/src/helix_gateway/builtin/nodes_by_label.rs | 5/5 | Updated to use arena-based deserialization, simplified nested conditionals, and updated test patterns |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as Builtin Handler
    participant Storage as HelixGraphStorage
    participant Arena as bumpalo::Bump
    participant DB as LMDB Database
    
    Client->>Handler: Request (e.g., nodes_edges_handler)
    Handler->>Handler: Create arena allocator
    Handler->>Storage: read_txn()
    Storage-->>Handler: RoTxn
    
    alt Get All Nodes & Edges
        Handler->>Storage: get_all_nodes_edges_json(txn, label, arena)
        Storage->>DB: nodes_db.iter(txn)
        DB-->>Storage: (id, raw_bytes)
        Storage->>Arena: Node::from_bincode_bytes(id, bytes, arena)
        Arena-->>Storage: Node<'arena>
        Storage->>Storage: Extract node.label & properties.iter()
        Storage->>DB: edges_db.iter(txn)
        DB-->>Storage: (id, raw_bytes)
        Storage->>Arena: Edge::from_bincode_bytes(id, bytes, arena)
        Arena-->>Storage: Edge<'arena>
        Storage-->>Handler: JSON string
    end
    
    alt Get Vectors
        Handler->>Storage: vectors.get_all_vectors(txn, level, arena)
        Storage->>DB: vectors_db.prefix_iter(txn)
        DB-->>Storage: vector keys
        loop For each vector
            Storage->>Storage: get_full_vector(txn, id, arena)
            Storage->>Arena: HVector allocation
            Arena-->>Storage: HVector<'arena>
        end
        Storage-->>Handler: Vec<HVector<'arena>>
    end
    
    Handler->>Handler: Serialize to JSON response
    Handler-->>Client: protocol::Response
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->