### PR TITLE
fix (hql): fixing hql with inner traversals

### DIFF
--- a/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
@@ -2,7 +2,7 @@ use crate::helixc::analyzer::error_codes::*;
 use crate::helixc::analyzer::utils::{
     DEFAULT_VAR_NAME, VariableInfo, check_identifier_is_fieldtype,
 };
-use crate::helixc::generator::bool_ops::{Contains, IsIn};
+use crate::helixc::generator::bool_ops::{Contains, IsIn, PropertyEq, PropertyNeq};
 use crate::helixc::generator::source_steps::{SearchVector, VFromID, VFromType};
 use crate::helixc::generator::traversal_steps::{AggregateBy, GroupBy};
 use crate::helixc::generator::utils::{EmbedData, VecData};
@@ -89,6 +89,45 @@ fn get_reserved_property_type(prop_name: &str, item_type: &Type) -> Option<Field
                 }
                 _ => None,
             }
+        }
+        _ => None,
+    }
+}
+
+/// Checks if a traversal is a "simple" property access (no graph navigation steps)
+/// and returns the variable name and property name if so.
+///
+/// A simple traversal is one that only accesses properties on an already-bound variable,
+/// without any graph navigation (Out, In, etc.). For example: `toUser::{login}`
+///
+/// Returns: Some((variable_name, property_name)) if simple, None otherwise
+fn is_simple_property_traversal(tr: &Traversal) -> Option<(String, String)> {
+    // Check if the start is an identifier (not a type-based query)
+    let var_name = match &tr.start {
+        StartNode::Identifier(id) => id.clone(),
+        _ => return None,
+    };
+
+    // Check if there's exactly one step and it's an Object (property access)
+    if tr.steps.len() != 1 {
+        return None;
+    }
+
+    // Check if the single step is an Object step (property access like {login})
+    match &tr.steps[0].step {
+        StepType::Object(obj) => {
+            // Check if it's a simple property fetch (single field, no spread)
+            if obj.fields.len() == 1 && !obj.should_spread {
+                let field = &obj.fields[0];
+                // Check if it's a simple field selection (Empty or Identifier, not a complex expression)
+                match &field.value.value {
+                    FieldValueType::Empty | FieldValueType::Identifier(_) => {
+                        return Some((var_name, field.key.clone()));
+                    }
+                    _ => return None,
+                }
+            }
+            None
         }
         _ => None,
     }
@@ -1170,7 +1209,32 @@ pub(crate) fn validate_traversal<'a>(
                         })
                     }
                     BooleanOpType::Equal(expr) => {
-                        let v = match &expr.expr {
+                        // Check if the right-hand side is a simple property traversal
+                        if let ExpressionType::Traversal(traversal) = &expr.expr {
+                            if let Some((var, property)) = is_simple_property_traversal(traversal) {
+                                // Use PropertyEq for simple traversals to avoid unnecessary G::from_iter
+                                BoolOp::PropertyEq(PropertyEq { var, property })
+                            } else {
+                                // Complex traversal - parse normally
+                                let mut gen_traversal = GeneratedTraversal::default();
+                                validate_traversal(
+                                    ctx,
+                                    traversal,
+                                    scope,
+                                    original_query,
+                                    parent_ty.clone(),
+                                    &mut gen_traversal,
+                                    gen_query,
+                                );
+                                gen_traversal.should_collect = ShouldCollect::ToValue;
+                                let v = GeneratedValue::Traversal(Box::new(gen_traversal));
+                                BoolOp::Eq(Eq {
+                                    left: GeneratedValue::Primitive(GenRef::Std("*v".to_string())),
+                                    right: v,
+                                })
+                            }
+                        } else {
+                            let v = match &expr.expr {
                             ExpressionType::BooleanLiteral(b) => {
                                 GeneratedValue::Primitive(GenRef::Std(b.to_string()))
                             }
@@ -1191,33 +1255,44 @@ pub(crate) fn validate_traversal<'a>(
                                     i.as_str(),
                                 );
                                 gen_identifier_or_param(original_query, i.as_str(), false, true)
-                            }
-                            ExpressionType::Traversal(traversal) => {
-                                // parse traversal
-                                let mut gen_traversal = GeneratedTraversal::default();
-                                validate_traversal(
-                                    ctx,
-                                    traversal,
-                                    scope,
-                                    original_query,
-                                    parent_ty.clone(),
-                                    &mut gen_traversal,
-                                    gen_query,
-                                );
-                                gen_traversal.should_collect = ShouldCollect::ToValue;
-                                GeneratedValue::Traversal(Box::new(gen_traversal))
                             }
                             _ => {
                                 unreachable!("Cannot reach here");
                             }
                         };
-                        BoolOp::Eq(Eq {
-                            left: GeneratedValue::Primitive(GenRef::Std("*v".to_string())),
-                            right: v,
-                        })
+                            BoolOp::Eq(Eq {
+                                left: GeneratedValue::Primitive(GenRef::Std("*v".to_string())),
+                                right: v,
+                            })
+                        }
                     }
                     BooleanOpType::NotEqual(expr) => {
-                        let v = match &expr.expr {
+                        // Check if the right-hand side is a simple property traversal
+                        if let ExpressionType::Traversal(traversal) = &expr.expr {
+                            if let Some((var, property)) = is_simple_property_traversal(traversal) {
+                                // Use PropertyNeq for simple traversals to avoid unnecessary G::from_iter
+                                BoolOp::PropertyNeq(PropertyNeq { var, property })
+                            } else {
+                                // Complex traversal - parse normally
+                                let mut gen_traversal = GeneratedTraversal::default();
+                                validate_traversal(
+                                    ctx,
+                                    traversal,
+                                    scope,
+                                    original_query,
+                                    parent_ty.clone(),
+                                    &mut gen_traversal,
+                                    gen_query,
+                                );
+                                gen_traversal.should_collect = ShouldCollect::ToValue;
+                                let v = GeneratedValue::Traversal(Box::new(gen_traversal));
+                                BoolOp::Neq(Neq {
+                                    left: GeneratedValue::Primitive(GenRef::Std("*v".to_string())),
+                                    right: v,
+                                })
+                            }
+                        } else {
+                            let v = match &expr.expr {
                             ExpressionType::BooleanLiteral(b) => {
                                 GeneratedValue::Primitive(GenRef::Std(b.to_string()))
                             }
@@ -1239,27 +1314,13 @@ pub(crate) fn validate_traversal<'a>(
                                 );
                                 gen_identifier_or_param(original_query, i.as_str(), false, true)
                             }
-                            ExpressionType::Traversal(traversal) => {
-                                // parse traversal
-                                let mut gen_traversal = GeneratedTraversal::default();
-                                validate_traversal(
-                                    ctx,
-                                    traversal,
-                                    scope,
-                                    original_query,
-                                    parent_ty.clone(),
-                                    &mut gen_traversal,
-                                    gen_query,
-                                );
-                                gen_traversal.should_collect = ShouldCollect::ToValue;
-                                GeneratedValue::Traversal(Box::new(gen_traversal))
-                            }
                             _ => unreachable!("Cannot reach here"),
                         };
-                        BoolOp::Neq(Neq {
-                            left: GeneratedValue::Primitive(GenRef::Std("*v".to_string())),
-                            right: v,
-                        })
+                            BoolOp::Neq(Neq {
+                                left: GeneratedValue::Primitive(GenRef::Std("*v".to_string())),
+                                right: v,
+                            })
+                        }
                     }
                     BooleanOpType::Contains(expr) => {
                         let v = match &expr.expr {

--- a/helix-db/src/helixc/generator/bool_ops.rs
+++ b/helix-db/src/helixc/generator/bool_ops.rs
@@ -18,6 +18,8 @@ pub enum BoolOp {
     Neq(Neq),
     Contains(Contains),
     IsIn(IsIn),
+    PropertyEq(PropertyEq),
+    PropertyNeq(PropertyNeq),
 }
 impl Display for BoolOp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -30,6 +32,8 @@ impl Display for BoolOp {
             BoolOp::Neq(neq) => format!("{neq}"),
             BoolOp::Contains(contains) => format!("v{contains}"),
             BoolOp::IsIn(is_in) => format!("v{is_in}"),
+            BoolOp::PropertyEq(prop_eq) => format!("{prop_eq}"),
+            BoolOp::PropertyNeq(prop_neq) => format!("{prop_neq}"),
         };
         write!(f, "map_value_or(false, |v| {s})?")
     }
@@ -97,6 +101,28 @@ pub struct Neq {
 impl Display for Neq {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} != {}", self.left, self.right)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PropertyEq {
+    pub var: String,
+    pub property: String,
+}
+impl Display for PropertyEq {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.get_property(\"{}\").map_or(false, |w| w == v)", self.var, self.property)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PropertyNeq {
+    pub var: String,
+    pub property: String,
+}
+impl Display for PropertyNeq {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.get_property(\"{}\").map_or(false, |w| w != v)", self.var, self.property)
     }
 }
 
@@ -241,6 +267,8 @@ impl Display for BoExp {
                             BoolOp::Neq(neq) => format!("{neq}"),
                             BoolOp::Contains(contains) => format!("v{contains}"),
                             BoolOp::IsIn(is_in) => format!("v{is_in}"),
+                            BoolOp::PropertyEq(prop_eq) => format!("{prop_eq}"),
+                            BoolOp::PropertyNeq(prop_neq) => format!("{prop_neq}"),
                         };
                         return write!(
                             f,

--- a/helix-db/src/helixc/generator/traversal_steps.rs
+++ b/helix-db/src/helixc/generator/traversal_steps.rs
@@ -476,6 +476,9 @@ impl Display for WhereRef {
                         BoolOp::Neq(neq) => format!("{} != {}", value_expr, neq.right),
                         BoolOp::Contains(contains) => format!("{}{}", value_expr, contains),
                         BoolOp::IsIn(is_in) => format!("{}{}", value_expr, is_in),
+                        BoolOp::PropertyEq(_) | BoolOp::PropertyNeq(_) => {
+                            unreachable!("PropertyEq/PropertyNeq should not be used with reserved properties")
+                        }
                     };
                     return write!(
                         f,
@@ -501,6 +504,8 @@ impl Display for WhereRef {
                         BoolOp::Neq(neq) => format!("{neq}"),
                         BoolOp::Contains(contains) => format!("v{contains}"),
                         BoolOp::IsIn(is_in) => format!("v{is_in}"),
+                        BoolOp::PropertyEq(prop_eq) => format!("{prop_eq}"),
+                        BoolOp::PropertyNeq(prop_neq) => format!("{prop_neq}"),
                     };
                     return write!(
                         f,

--- a/hql-tests/test.sh
+++ b/hql-tests/test.sh
@@ -11,8 +11,8 @@ fi
 file_name=$1
 
 
-helix compile --path "/Users/xav/GitHub/helix-db/hql-tests/tests/$file_name" --output "/Users/xav/GitHub/helix-db/helix-container/src"
-output=$(cargo check --manifest-path "/Users/xav/GitHub/helix-db/helix-container/Cargo.toml")
+helix compile --path "/Users/xav/GitHub/helix-db-core/hql-tests/tests/$file_name" --output "/Users/xav/GitHub/helix-db-core/helix-container/src"
+output=$(cargo check --manifest-path "/Users/xav/GitHub/helix-db-core/helix-container/Cargo.toml")
 if [ $? -ne 0 ]; then
     echo "Error: Cargo check failed"
     echo "Cargo check output: $output"
@@ -20,7 +20,3 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Cargo check passed"
-
-
-
-

--- a/hql-tests/tests/user_test_2/helix.toml
+++ b/hql-tests/tests/user_test_2/helix.toml
@@ -1,0 +1,9 @@
+[project]
+name = "where_filter"
+queries = "."
+
+[local.dev]
+port = 6969
+build_mode = "debug"
+
+[cloud]

--- a/hql-tests/tests/user_test_2/queries.hx
+++ b/hql-tests/tests/user_test_2/queries.hx
@@ -1,0 +1,156 @@
+QUERY createUser (login: String, userType: String, nodeCreateTime: Date) =>
+    user <- AddN<GitHubUser>({
+        login: login,
+        isEnriched: false,
+        userType: userType,
+        nodeCreateTime: nodeCreateTime
+    })
+
+    RETURN user
+
+QUERY updateUser(login: ID, isEnriched: Boolean, name: String, company: String, location: String, email: String, bio: String, publicRepos: I64, blog: String, twitterUsername: String, followers: I64, following: I64, nodeUpdateTime: Date) =>
+    updated <- N<GitHubUser>(login)::UPDATE({
+        isEnriched: isEnriched,
+        name: name,
+        company: company,
+        location: location,
+        email: email,
+        bio: bio,
+        publicRepos: publicRepos,
+        blog: blog,
+        twitterUsername: twitterUsername,
+        followers: followers,
+        following: following,
+        nodeUpdateTime: nodeUpdateTime
+    })
+
+    RETURN updated
+
+
+QUERY createRepo (name: String, fullName: String, ownerType: String, description: String, createdAt: Date, updatedAt: Date, pushedAt: Date, homepage: String, stargazerCount: I64, subscriberCount: I64, language: String, forkCount: I64, openIssueCount: I64, hasWiki: Boolean, hasDiscussions: Boolean, isFork: Boolean, isArchived: Boolean, topics: [String], nodeCreateTime: Date) =>
+    repo <- AddN<GitHubRepo>({
+        name: name,
+        fullName: fullName,
+        ownerType: ownerType,
+        description: description,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+        pushedAt: pushedAt,
+        homepage: homepage,
+        stargazerCount: stargazerCount,
+        subscriberCount: subscriberCount,
+        language: language,
+        forkCount: forkCount,
+        openIssueCount: openIssueCount,
+        hasWiki: hasWiki,
+        hasDiscussions: hasDiscussions,
+        isFork: isFork,
+        isArchived: isArchived,
+        topics: topics,
+        nodeCreateTime: nodeCreateTime
+    })
+
+    RETURN repo
+
+QUERY createCreatedRepoEdge (fromUserId: String, toRepoId: String, edgeWriteTime: Date) =>
+    fromUser <- N<GitHubUser>({login: fromUserId})
+    toRepo <- N<GitHubRepo>({fullName: toRepoId})
+
+    edge <- AddE<CreatedRepo>({
+        edgeWriteTime: edgeWriteTime
+    })::From(fromUser)::To(toRepo)
+
+    RETURN edge
+
+QUERY createStarredRepoEdge (fromUserId: String, toRepoId: String, starredAt: Date, edgeWriteTime: Date) =>
+    fromUser <- N<GitHubUser>({login: fromUserId})
+    toRepo <- N<GitHubRepo>({fullName: toRepoId})
+
+    edge <- AddE<StarredRepo>({
+        starredAt: starredAt,
+        edgeWriteTime: edgeWriteTime
+    })::From(fromUser)::To(toRepo)
+
+    RETURN edge
+
+QUERY createSubscribedRepoEdge (fromUserId: String, toRepoId: String, edgeWriteTime: Date) =>
+    fromUser <- N<GitHubUser>({login: fromUserId})
+    toRepo <- N<GitHubRepo>({fullName: toRepoId})
+
+    edge <- AddE<SubscribedRepo>({
+        edgeWriteTime: edgeWriteTime
+    })::From(fromUser)::To(toRepo)
+
+    RETURN edge
+
+QUERY createFollowsEdge (fromUserId: String, toUserId: String, edgeWriteTime: Date) =>
+    fromUser <- N<GitHubUser>({login: fromUserId})
+    toUser <- N<GitHubUser>({login: toUserId})
+
+    edge <- AddE<Follows>({
+        edgeWriteTime: edgeWriteTime
+    })::From(fromUser)::To(toUser)
+
+    RETURN edge
+
+QUERY getAllFollowers (userId: String) =>
+    user <- N<GitHubUser>({login: userId})
+    followers <- user::In<Follows>
+
+    RETURN followers
+
+QUERY getUser (login: String) =>
+    user <- N<GitHubUser>({login: login})
+
+    RETURN user
+
+QUERY getRepo (fullName: String) =>
+    repo <- N<GitHubRepo>({fullName: fullName})
+
+    RETURN repo
+
+QUERY getAllUsers () =>
+    users <- N<GitHubUser>
+    RETURN users
+
+QUERY getAllRepos () =>
+    repos <- N<GitHubRepo>
+    RETURN repos
+
+QUERY getAllCreatedRepoEdges () =>
+    edges <- E<CreatedRepo>
+    RETURN edges
+
+QUERY getAllStarredRepoEdges () =>
+    edges <- E<StarredRepo>
+    RETURN edges
+
+QUERY getAllSubscribedRepoEdges () =>
+    edges <- E<SubscribedRepo>
+    RETURN edges
+
+QUERY getAllFollowsEdges () =>
+    edges <- E<Follows>
+    RETURN edges
+
+QUERY RemoveAllFollowsEdges() =>
+    DROP E<Follows>
+    RETURN "success"
+
+QUERY getUsersWhoAreStargazers () =>
+    users <- N<GitHubUser>::WHERE(EXISTS(_::Out<StarredRepo>))
+    RETURN users
+
+QUERY getUsersWhoAreSubscribers () =>
+    users <- N<GitHubUser>::WHERE(EXISTS(_::Out<SubscribedRepo>))
+    RETURN users
+
+QUERY getUsersWhoHaveCreatedRepos () =>
+    users <- N<GitHubUser>::WHERE(EXISTS(_::Out<CreatedRepo>))
+    RETURN users
+
+QUERY CheckFollowsEdge(fromUserId: String, toUserId: String) =>
+    fromUser <- N<GitHubUser>({login: fromUserId})
+    toUser <- N<GitHubUser>({login: toUserId})
+    result <- fromUser::Out<Follows>::WHERE(_::{login}::EQ(toUser::{login}))
+    RETURN result

--- a/hql-tests/tests/user_test_2/schema.hx
+++ b/hql-tests/tests/user_test_2/schema.hx
@@ -1,0 +1,105 @@
+N::GitHubUser {
+    INDEX login: String,
+    isEnriched: Boolean,
+    userType: String,
+    name: String DEFAULT "",
+    company: String DEFAULT "",
+    location: String DEFAULT "",
+    email: String DEFAULT "",
+    bio: String DEFAULT "",
+    publicRepos: I64 DEFAULT 0,
+    blog: String DEFAULT "",
+    twitterUsername: String DEFAULT "",
+    followers: I64 DEFAULT 0,
+    following: I64 DEFAULT 0,
+    nodeCreateTime: Date,
+    nodeUpdateTime: Date DEFAULT "2000-01-01T00:00:00Z",
+}
+
+N::GitHubRepo {
+    name: String,
+    INDEX fullName: String,
+    ownerType: String,
+    description: String,
+    createdAt: Date,
+    updatedAt: Date,
+    pushedAt: Date,
+    homepage: String,
+    language: String,
+    stargazerCount: I64,
+    subscriberCount: I64,
+    forkCount: I64,
+    openIssueCount: I64,
+    hasWiki: Boolean,
+    hasDiscussions: Boolean,
+    isFork: Boolean,
+    isArchived: Boolean,
+    topics: [String],
+    nodeCreateTime: Date,
+}
+
+E::CreatedRepo {
+    From: GitHubUser,
+    To: GitHubRepo,
+    Properties: {
+        edgeWriteTime: Date,
+    }
+}
+
+E::StarredRepo {
+    From: GitHubUser,
+    To: GitHubRepo,
+    Properties: {
+        starredAt: Date,
+        edgeWriteTime: Date,
+    }
+}
+
+E::SubscribedRepo {
+    From: GitHubUser,
+    To: GitHubRepo,
+    Properties: {
+        edgeWriteTime: Date,
+    }
+}
+
+E::ContributedTo {
+    From: GitHubUser,
+    To: GitHubRepo,
+    Properties: {
+        contributionsCount: I64,
+        edgeWriteTime: Date,
+    }
+}
+
+E::AffiliatedWith {
+    From: GitHubUser,
+    To: GitHubUser,
+    Properties: {
+        edgeWriteTime: Date,
+    }
+}
+
+E::ForkedRepo {
+    From: GitHubRepo,
+    To: GitHubRepo,
+    Properties: {
+        edgeWriteTime: Date,
+    }
+}
+
+E::Follows {
+    From: GitHubUser,
+    To: GitHubUser,
+    Properties: {
+        edgeWriteTime: Date,
+    }
+}
+
+E::DependsOn {
+    From: GitHubRepo,
+    To: GitHubRepo,
+    Properties: {
+        edgeWriteTime: Date,
+    }
+}

--- a/hql-tests/tests/user_test_3/helix.toml
+++ b/hql-tests/tests/user_test_3/helix.toml
@@ -1,0 +1,9 @@
+[project]
+name = "where_filter"
+queries = "."
+
+[local.dev]
+port = 6969
+build_mode = "debug"
+
+[cloud]

--- a/hql-tests/tests/user_test_3/queries.hx
+++ b/hql-tests/tests/user_test_3/queries.hx
@@ -1,0 +1,55 @@
+QUERY add_document(filename: String, upload_date: String, filetype: String, total_elements: I64) =>
+  doc <- AddN<Document>({filename: filename, upload_date: upload_date, filetype: filetype, total_elements: total_elements})
+  RETURN doc
+
+QUERY add_chunk_with_metadata(
+  doc_filename: String,
+  element_id: String,
+  text: String,
+  element_type: String,
+  page_number: I64,
+  parent_id: String,
+  category_depth: I64,
+  metadata_json: String,
+  order: I64,
+  upload_date: String
+) =>
+  doc <- N<Document>({filename: doc_filename})
+  chunk <- AddN<Chunk>({
+    element_id: element_id,
+    text: text,
+    element_type: element_type,
+    page_number: page_number,
+    parent_id: parent_id,
+    category_depth: category_depth,
+    metadata_json: metadata_json,
+    order: order
+  })
+  edge <- AddE<HAS_CHUNK>::From(doc)::To(chunk)
+  RETURN chunk
+
+QUERY add_embedding(chunk_element_id: String, vec: [F64]) =>
+  chunk <- N<Chunk>({element_id: chunk_element_id})
+  embedding <- AddV<ChunkEmbedding>(vec, {chunk_id: chunk_element_id})
+  edge <- AddE<HAS_EMBEDDING>::From(chunk)::To(embedding)
+  RETURN embedding
+
+QUERY get_all_documents() =>
+  docs <- N<Document>
+  RETURN docs
+
+QUERY get_document_chunks(doc_filename: String) =>
+  doc <- N<Document>({filename: doc_filename})
+  chunks <- doc::Out<HAS_CHUNK>
+  RETURN chunks
+
+QUERY search_similar_chunks(query_vec: [F64], limit: I64) =>
+  embeddings <- SearchV<ChunkEmbedding>(query_vec, limit)
+  chunks <- embeddings::In<HAS_EMBEDDING>
+  RETURN chunks
+
+QUERY get_chunk_with_context(element_id: String) =>
+  chunk <- N<Chunk>({element_id: element_id})
+  parent <- chunk::Out<HAS_PARENT>
+  doc <- chunk::In<HAS_CHUNK>
+  RETURN {chunk: chunk, parent: parent, document: doc}

--- a/hql-tests/tests/user_test_3/schema.hx
+++ b/hql-tests/tests/user_test_3/schema.hx
@@ -1,0 +1,36 @@
+N::Document {
+    INDEX filename: String,
+    upload_date: String,
+    filetype: String,
+    total_elements: I64
+}
+
+N::Chunk {
+    INDEX element_id: String,
+    text: String,
+    element_type: String,
+    page_number: I64,
+    parent_id: String,
+    category_depth: I64,
+    metadata_json: String,
+    order: I64
+}
+
+V::ChunkEmbedding {
+    chunk_id: String
+}
+
+E::HAS_CHUNK {
+    From: Document,
+    To: Chunk
+}
+
+E::HAS_PARENT {
+    From: Chunk,
+    To: Chunk
+}
+
+E::HAS_EMBEDDING {
+    From: Chunk,
+    To: ChunkEmbedding
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Optimized HQL compiler to handle inner traversals in WHERE clause comparisons. Previously, comparing properties from different variables (e.g., `_::{login}::EQ(toUser::{login})`) would generate inefficient code with unnecessary `G::from_iter` calls. The fix introduces `PropertyEq` and `PropertyNeq` operators that detect simple property access patterns and generate direct `get_property()` calls instead.

**Key Changes:**
- Added `is_simple_property_traversal()` helper that identifies property-only traversals (no graph navigation)
- Created `PropertyEq` and `PropertyNeq` boolean operators for optimized property comparisons
- Updated Equal/NotEqual handling in `traversal_validation.rs` to use optimized path for simple cases
- Added comprehensive test coverage with GitHub graph and document embedding schemas

**Impact:**
- Enables queries like `CheckFollowsEdge` that filter edges by comparing properties across variables
- Generates more efficient Rust code for common property comparison patterns
- Maintains backward compatibility by falling back to full traversal parsing for complex cases

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/helixc/analyzer/methods/traversal_validation.rs | 5/5 | Added `is_simple_property_traversal` helper function and optimized Equal/NotEqual operators to use PropertyEq/PropertyNeq for simple property access, avoiding unnecessary `G::from_iter` calls |
| helix-db/src/helixc/generator/bool_ops.rs | 5/5 | Added PropertyEq and PropertyNeq boolean operators that generate optimized property comparison code using `get_property` instead of creating full traversals |
| helix-db/src/helixc/generator/traversal_steps.rs | 5/5 | Updated WhereRef Display implementation to handle new PropertyEq/PropertyNeq boolean operators with unreachable guard for reserved properties |
| hql-tests/tests/user_test_2/queries.hx | 5/5 | New GitHub-style graph queries including `CheckFollowsEdge` query that uses inner traversal comparison pattern `_::{login}::EQ(toUser::{login})` |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as HQL Query
    participant Analyzer as traversal_validation.rs
    participant BoolOps as bool_ops.rs
    participant Generator as traversal_steps.rs
    participant Output as Generated Rust Code

    User->>Analyzer: WHERE(_::{login}::EQ(toUser::{login}))
    Analyzer->>Analyzer: Validate BooleanOpType::Equal
    Analyzer->>Analyzer: Check if RHS is ExpressionType::Traversal
    Analyzer->>Analyzer: Call is_simple_property_traversal()
    
    alt Simple property traversal
        Analyzer->>Analyzer: Detected: toUser::{login}
        Analyzer->>BoolOps: Create PropertyEq(var: "toUser", property: "login")
        BoolOps->>Generator: Pass PropertyEq to WhereRef
        Generator->>Output: Generate: toUser.get_property("login").map_or(false, |w| w == v)
    else Complex traversal
        Analyzer->>Analyzer: Parse full traversal with validate_traversal()
        Analyzer->>BoolOps: Create Eq with GeneratedValue::Traversal
        BoolOps->>Generator: Pass Eq with traversal
        Generator->>Output: Generate: G::from_iter(...) comparison
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->