### PR TITLE
fix filepath issue

### DIFF
--- a/helix-db/src/helixc/parser/schema_parse_methods.rs
+++ b/helix-db/src/helixc/parser/schema_parse_methods.rs
@@ -22,7 +22,7 @@ impl HelixParser {
         let name = pairs.try_next()?.as_str().to_string();
         let fields = self.parse_node_body(pairs.try_next()?, filepath.clone())?;
         Ok(NodeSchema {
-            name: (pair.loc(), name),
+            name: (pair.loc_with_filepath(filepath.clone()), name),
             fields,
             loc: pair.loc_with_filepath(filepath),
         })
@@ -498,7 +498,7 @@ impl HelixParser {
         };
 
         Ok(EdgeSchema {
-            name: (pair.loc(), name),
+            name: (pair.loc_with_filepath(filepath.clone()), name),
             from,
             to,
             properties,


### PR DESCRIPTION
## Description
Helixdb cli tool when running helix push dev correctly detects the error but tags the wrong file. so this PR resolves this issue

## Related Issues
Closes #719

## Checklist when merging to main

- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [x] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
Here is a image that shows new output 
<img width="998" height="274" alt="image" src="https://github.com/user-attachments/assets/cb1c4b1c-2d8e-40ad-8157-fae43eca3836" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed incorrect file path reporting in duplicate schema definition errors by ensuring the `name` field location includes the filepath for both nodes and edges.

**Key Changes:**
- Updated `parse_node_def` to use `pair.loc_with_filepath(filepath.clone())` instead of `pair.loc()` for the node name location (line 25)
- Updated `parse_edge_def` to use `pair.loc_with_filepath(filepath.clone())` instead of `pair.loc()` for the edge name location (line 501)
- This ensures that when the analyzer detects duplicate definitions and reports errors using `edge.name.0` or `node.name.0`, the `Loc` struct contains the correct `filepath` field

**Impact:**
- Resolves issue #719 where duplicate edge relationships in `schema.hx` were incorrectly reported as being in `queries.hx`
- The line numbers were already correct, but now the filename is also accurate in error messages

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/helixc/parser/schema_parse_methods.rs | 5/5 | Fixed filepath tagging for node and edge name locations by using `loc_with_filepath()` instead of `loc()`, ensuring error messages correctly report the file where duplicate definitions occur. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as helix push dev
    participant Parser as HelixParser
    participant Schema as parse_node_def/parse_edge_def
    participant Analyzer as check_duplicate_schema_definitions
    participant Error as Error Reporter
    
    CLI->>Parser: Parse schema files
    Parser->>Schema: parse_edge_def(pair, filepath)
    Note over Schema: OLD: name: (pair.loc(), name)<br/>NEW: name: (pair.loc_with_filepath(filepath), name)
    Schema-->>Parser: EdgeSchema with name location
    Parser->>Schema: parse_node_def(pair, filepath)
    Note over Schema: OLD: name: (pair.loc(), name)<br/>NEW: name: (pair.loc_with_filepath(filepath), name)
    Schema-->>Parser: NodeSchema with name location
    Parser->>Analyzer: check_duplicate_schema_definitions
    Note over Analyzer: Detects duplicate edge "Has_product"
    Analyzer->>Error: push_schema_err(edge.name.0, ...)
    Note over Error: edge.name.0 now contains correct filepath<br/>(schema.hx instead of queries.hx)
    Error-->>CLI: Display error with correct file path
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->