### PR TITLE
fixing helixc panics

### DIFF
--- a/helix-db/src/helixc/analyzer/error_codes.rs
+++ b/helix-db/src/helixc/analyzer/error_codes.rs
@@ -93,6 +93,10 @@ pub enum ErrorCode {
     E625,
     /// `E626` - `edge type does not have a vector type as its To source`
     E626,
+    /// `E627` - `shortest path requires from or to parameter`
+    E627,
+    /// `E628` - `DROP can only be applied to traversals`
+    E628,
 
     /// `E631` - `range must have a start and end`
     E631,
@@ -167,6 +171,8 @@ impl std::fmt::Display for ErrorCode {
             ErrorCode::E624 => write!(f, "E624"),
             ErrorCode::E625 => write!(f, "E625"),
             ErrorCode::E626 => write!(f, "E626"),
+            ErrorCode::E627 => write!(f, "E627"),
+            ErrorCode::E628 => write!(f, "E628"),
             ErrorCode::E631 => write!(f, "E631"),
             ErrorCode::E632 => write!(f, "E632"),
             ErrorCode::E633 => write!(f, "E633"),
@@ -260,6 +266,8 @@ implement_error_code!(E623, "edge type `{}` does not have a node type as its `Fr
 implement_error_code!(E624, "edge type `{}` does not have a node type as its `To` source" => { edge_type }, "set the `To` type of the edge to a node type" => {});
 implement_error_code!(E625, "edge type `{}` does not have a vector type as its `From` source" => { edge_type }, "set the `From` type of the edge to a vector type" => {});
 implement_error_code!(E626, "edge type `{}` does not have a vector type as its `To` source" => { edge_type }, "set the `To` type of the edge to a vector type" => {});
+implement_error_code!(E627, "`{}` requires either a `from` or `to` parameter" => { step_name }, "add a `from` or `to` parameter to the step" => {});
+implement_error_code!(E628, "`DROP` can only be applied to traversals, but got `{}`" => { expression_type }, "ensure the expression is a traversal" => {});
 
 // Range errors
 implement_error_code!(E631, "range must have a start and end, missing the `{}` value" => { start_or_end }, "add a `{}` value to the range" => { start_or_end });

--- a/helix-db/src/helixc/analyzer/methods/graph_step_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/graph_step_validation.rs
@@ -387,7 +387,10 @@ pub(crate) fn apply_graph_step<'a>(
                             to: Some(GenRef::from(to)),
                             algorithm,
                         },
-                        (None, None) => panic!("Invalid shortest path"),
+                        (None, None) => {
+                            generate_error!(ctx, original_query, sp.loc.clone(), E627, "ShortestPath");
+                            return None;
+                        }
                     },
                 )));
             traversal.should_collect = ShouldCollect::ToVec;
@@ -511,7 +514,10 @@ pub(crate) fn apply_graph_step<'a>(
                             to: Some(GenRef::from(to)),
                             weight_calculation: weight_calculation.clone(),
                         },
-                        (None, None) => panic!("Invalid shortest path dijkstras"),
+                        (None, None) => {
+                            generate_error!(ctx, original_query, sp.loc.clone(), E627, "ShortestPathDijkstras");
+                            return None;
+                        }
                     },
                 )));
             traversal.should_collect = ShouldCollect::ToVec;
@@ -539,7 +545,10 @@ pub(crate) fn apply_graph_step<'a>(
                             from: None,
                             to: Some(GenRef::from(to)),
                         },
-                        (None, None) => panic!("Invalid shortest path bfs"),
+                        (None, None) => {
+                            generate_error!(ctx, original_query, sp.loc.clone(), E627, "ShortestPathBFS");
+                            return None;
+                        }
                     },
                 )));
             traversal.should_collect = ShouldCollect::ToVec;
@@ -602,7 +611,10 @@ pub(crate) fn apply_graph_step<'a>(
                             weight_calculation,
                             heuristic_property,
                         },
-                        (None, None) => panic!("Invalid shortest path astar"),
+                        (None, None) => {
+                            generate_error!(ctx, original_query, sp.loc.clone(), E627, "ShortestPathAStar");
+                            return None;
+                        }
                     },
                 )));
             traversal.should_collect = ShouldCollect::ToVec;

--- a/helix-db/src/helixc/analyzer/methods/statement_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/statement_validation.rs
@@ -82,7 +82,7 @@ pub(crate) fn validate_statements<'a>(
         }
 
         Drop(expr) => {
-            let (_, stmt) = infer_expr_type(ctx, expr, scope, original_query, None, query);
+            let (expr_ty, stmt) = infer_expr_type(ctx, expr, scope, original_query, None, query);
             stmt.as_ref()?;
 
             query.is_mut = true;
@@ -91,7 +91,8 @@ pub(crate) fn validate_statements<'a>(
                 tr.should_collect = ShouldCollect::No;
                 Some(GeneratedStatement::Drop(GeneratedDrop { expression: tr }))
             } else {
-                panic!("Drop should only be applied to traversals");
+                generate_error!(ctx, original_query, expr.loc.clone(), E628, &expr_ty.get_type_name());
+                None
             }
         }
 

--- a/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
@@ -1484,12 +1484,14 @@ pub(crate) fn validate_traversal<'a>(
                                         ExpressionType::BooleanLiteral(i) => {
                                             GeneratedValue::Primitive(GenRef::Std(i.to_string()))
                                         }
-                                        _ => {
-                                            panic!("expr be primitive or value")
+                                        other => {
+                                            generate_error!(ctx, original_query, e.loc.clone(), E206, &format!("{:?}", other));
+                                            GeneratedValue::Unknown
                                         }
                                     },
-                                    _ => {
-                                        panic!("Should be primitive or value")
+                                    other => {
+                                        generate_error!(ctx, original_query, field.value.loc.clone(), E206, &format!("{:?}", other));
+                                        GeneratedValue::Unknown
                                     }
                                 },
                             )

--- a/helix-db/src/helixc/parser/expression_parse_methods.rs
+++ b/helix-db/src/helixc/parser/expression_parse_methods.rs
@@ -65,16 +65,20 @@ impl HelixParser {
                     .next()
                     .ok_or_else(|| ParserError::from("Missing traversal"))?;
 
+                let parsed_traversal = match traversal.as_rule() {
+                    Rule::anonymous_traversal => self.parse_anon_traversal(traversal)?,
+                    Rule::id_traversal => self.parse_traversal(traversal)?,
+                    Rule::traversal => self.parse_traversal(traversal)?,
+                    other => return Err(ParserError::from(format!(
+                        "Unexpected rule in exists expression: {:?}",
+                        other
+                    ))),
+                };
                 let expr = ExpressionType::Exists(ExistsExpression {
                     loc: loc.clone(),
                     expr: Box::new(Expression {
                         loc: loc.clone(),
-                        expr: ExpressionType::Traversal(Box::new(match traversal.as_rule() {
-                            Rule::anonymous_traversal => self.parse_anon_traversal(traversal)?,
-                            Rule::id_traversal => self.parse_traversal(traversal)?,
-                            Rule::traversal => self.parse_traversal(traversal)?,
-                            _ => unreachable!(),
-                        })),
+                        expr: ExpressionType::Traversal(Box::new(parsed_traversal)),
                     }),
                 });
                 Ok(Expression {
@@ -215,16 +219,20 @@ impl HelixParser {
                 let traversal = inner
                     .next()
                     .ok_or_else(|| ParserError::from("Missing traversal"))?;
+                let parsed_traversal = match traversal.as_rule() {
+                    Rule::anonymous_traversal => self.parse_anon_traversal(traversal)?,
+                    Rule::id_traversal => self.parse_traversal(traversal)?,
+                    Rule::traversal => self.parse_traversal(traversal)?,
+                    other => return Err(ParserError::from(format!(
+                        "Unexpected rule in and_or_expression exists: {:?}",
+                        other
+                    ))),
+                };
                 let expr = ExpressionType::Exists(ExistsExpression {
                     loc: loc.clone(),
                     expr: Box::new(Expression {
                         loc: loc.clone(),
-                        expr: ExpressionType::Traversal(Box::new(match traversal.as_rule() {
-                            Rule::anonymous_traversal => self.parse_anon_traversal(traversal)?,
-                            Rule::id_traversal => self.parse_traversal(traversal)?,
-                            Rule::traversal => self.parse_traversal(traversal)?,
-                            _ => unreachable!(),
-                        })),
+                        expr: ExpressionType::Traversal(Box::new(parsed_traversal)),
                     }),
                 });
                 Ok(Expression {
@@ -239,7 +247,10 @@ impl HelixParser {
                 })
             }
 
-            _ => unreachable!(),
+            other => Err(ParserError::from(format!(
+                "Unexpected rule in parse_and_or_expression: {:?}",
+                other
+            ))),
         }
     }
     pub(super) fn parse_expression_vec(
@@ -270,7 +281,10 @@ impl HelixParser {
                 Rule::evaluates_to_bool => {
                     expressions.push(self.parse_boolean_expression(p)?);
                 }
-                _ => unreachable!(),
+                other => return Err(ParserError::from(format!(
+                    "Unexpected rule in parse_expression_vec: {:?}",
+                    other
+                ))),
             }
         }
         Ok(expressions)

--- a/helix-db/src/helixc/parser/graph_step_parse_methods.rs
+++ b/helix-db/src/helixc/parser/graph_step_parse_methods.rs
@@ -20,10 +20,14 @@ impl HelixParser {
     /// ```
     pub(super) fn parse_order_by(&self, pair: Pair<Rule>) -> Result<OrderBy, ParserError> {
         let mut inner = pair.clone().into_inner();
-        let order_by_type = match inner.try_next_inner().try_next()?.as_rule() {
+        let order_by_rule = inner.try_next_inner().try_next()?;
+        let order_by_type = match order_by_rule.as_rule() {
             Rule::asc => OrderByType::Asc,
             Rule::desc => OrderByType::Desc,
-            _ => unreachable!(),
+            other => return Err(ParserError::from(format!(
+                "Unexpected rule in parse_order_by: {:?}",
+                other
+            ))),
         };
         let expression = self.parse_expression(inner.try_next()?)?;
         Ok(OrderBy {
@@ -408,7 +412,10 @@ impl HelixParser {
                                     Some(p.try_inner_next()?.as_str().to_string()),
                                     to,
                                 )),
-                                _ => unreachable!(),
+                                other => Err(ParserError::from(format!(
+                                    "Unexpected rule in shortest_path to_from: {:?}",
+                                    other
+                                ))),
                             },
                             None => Ok((type_arg, from, to)),
                         },
@@ -469,7 +476,10 @@ impl HelixParser {
                                         Some(p.into_inner().next().unwrap().as_str().to_string()),
                                         to,
                                     )),
-                                    _ => unreachable!(),
+                                    other => Err(ParserError::from(format!(
+                                        "Unexpected rule in shortest_path_dijkstras to_from: {:?}",
+                                        other
+                                    ))),
                                 },
                                 None => Ok((type_arg, weight_expr, from, to)),
                             },
@@ -542,7 +552,10 @@ impl HelixParser {
                                     Some(p.into_inner().next().unwrap().as_str().to_string()),
                                     to,
                                 )),
-                                _ => unreachable!(),
+                                other => Err(ParserError::from(format!(
+                                    "Unexpected rule in shortest_path_bfs to_from: {:?}",
+                                    other
+                                ))),
                             },
                             None => Ok((type_arg, from, to)),
                         },

--- a/helix-db/src/helixc/parser/schema_parse_methods.rs
+++ b/helix-db/src/helixc/parser/schema_parse_methods.rs
@@ -249,7 +249,10 @@ impl HelixParser {
                                             ))
                                         })?,
                                     ),
-                                    _ => unreachable!(), // throw error
+                                    other => return Err(ParserError::from(format!(
+                                        "Float default value not valid for field type {:?}",
+                                        other
+                                    ))),
                                 }
                             }
                             Rule::integer => {
@@ -326,7 +329,10 @@ impl HelixParser {
                                             ))
                                         })?,
                                     ),
-                                    _ => unreachable!(), // throw error
+                                    other => return Err(ParserError::from(format!(
+                                        "Integer default value not valid for field type {:?}",
+                                        other
+                                    ))),
                                 }
                             }
                             Rule::now => DefaultValue::Now,
@@ -338,7 +344,10 @@ impl HelixParser {
                                     ))
                                 })?,
                             ),
-                            _ => unreachable!(), // throw error
+                            other => return Err(ParserError::from(format!(
+                                "Unexpected rule for default value: {:?}",
+                                other
+                            ))),
                         },
                         None => DefaultValue::Empty,
                     };
@@ -405,7 +414,10 @@ impl HelixParser {
                     "U32" => Ok(FieldType::U32),
                     "U64" => Ok(FieldType::U64),
                     "U128" => Ok(FieldType::U128),
-                    _ => unreachable!(),
+                    other => Err(ParserError::from(format!(
+                        "Unknown named type: {}",
+                        other
+                    ))),
                 }
             }
             Rule::array => {
@@ -434,9 +446,10 @@ impl HelixParser {
             Rule::identifier => Ok(FieldType::Identifier(field.as_str().to_string())),
             Rule::ID_TYPE => Ok(FieldType::Uuid),
             Rule::date_type => Ok(FieldType::Date),
-            _ => {
-                unreachable!()
-            }
+            other => Err(ParserError::from(format!(
+                "Unexpected rule in parse_field_type: {:?}",
+                other
+            ))),
         }
     }
 

--- a/helix-db/src/helixc/parser/traversal_parse_methods.rs
+++ b/helix-db/src/helixc/parser/traversal_parse_methods.rs
@@ -137,7 +137,10 @@ impl HelixParser {
                                             ));
                                         }
                                     },
-                                    _ => unreachable!(),
+                                    other => return Err(ParserError::from(format!(
+                                        "Unexpected rule in start_node by_index: {:?}",
+                                        other
+                                    ))),
                                 };
                                 vec![IdType::ByIndex {
                                     index: Box::new(index),
@@ -146,7 +149,10 @@ impl HelixParser {
                                 }]
                             })
                         }
-                        _ => unreachable!(),
+                        other => return Err(ParserError::from(format!(
+                            "Unexpected rule in start_node: {:?}",
+                            other
+                        ))),
                     }
                 }
                 Ok(StartNode::Node { node_type, ids })
@@ -185,7 +191,10 @@ impl HelixParser {
                             }
                             ids = Some(new_ids);
                         }
-                        _ => unreachable!(),
+                        other => return Err(ParserError::from(format!(
+                            "Unexpected rule in start_edge: {:?}",
+                            other
+                        ))),
                     }
                 }
                 Ok(StartNode::Edge { edge_type, ids })
@@ -292,7 +301,10 @@ impl HelixParser {
                             }
                             ids = Some(new_ids);
                         }
-                        _ => unreachable!(),
+                        other => return Err(ParserError::from(format!(
+                            "Unexpected rule in start_vector: {:?}",
+                            other
+                        ))),
                     }
                 }
                 Ok(StartNode::Vector { vector_type, ids })

--- a/helix-db/src/helixc/parser/types.rs
+++ b/helix-db/src/helixc/parser/types.rs
@@ -1085,7 +1085,10 @@ impl From<Value> for ValueType {
                 value: Value::Empty,
                 loc: Loc::empty(),
             },
-            _ => unreachable!(),
+            other => ValueType::Literal {
+                value: other,
+                loc: Loc::empty(),
+            },
         }
     }
 }

--- a/helix-db/src/helixc/parser/utils.rs
+++ b/helix-db/src/helixc/parser/utils.rs
@@ -72,7 +72,10 @@ impl HelixParser {
                 Rule::to => {
                     to_id = self.parse_id_args(p.into_inner().next().unwrap())?;
                 }
-                _ => unreachable!(),
+                _ => return Err(ParserError::from(format!(
+                    "Unexpected rule in parse_to_from: {:?}",
+                    p.as_rule()
+                ))),
             }
         }
         Ok(EdgeConnection {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Replaces `panic!()` and `unreachable!()` macros throughout the helixc compiler with proper error handling using descriptive error messages.

## Key Changes
- **Added two new error codes**: E627 for shortest path algorithms missing required `from`/`to` parameters, and E628 for invalid `DROP` usage on non-traversals
- **Replaced 4 panics in graph step validation**: ShortestPath, ShortestPathDijkstras, ShortestPathBFS, and ShortestPathAStar now return E627 errors instead of panicking when both `from` and `to` are missing
- **Replaced panic in statement validation**: `DROP` statement now generates E628 error when applied to non-traversal expressions
- **Replaced 2 panics in traversal validation**: Invalid field value types now generate E206 errors with `GeneratedValue::Unknown` fallback
- **Replaced 15+ `unreachable!()` calls in parser**: All parser methods now return descriptive `ParserError` messages for unexpected grammar rules

## Impact
This PR significantly improves compiler robustness by ensuring invalid HelixQL queries produce helpful error messages instead of crashing the compiler. All panic paths have been replaced with proper error propagation that provides context to users about what went wrong.

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/helixc/analyzer/error_codes.rs | 5/5 | Added two new error codes (E627 for missing shortest path parameters, E628 for invalid DROP usage) with proper documentation and implementations |
| helix-db/src/helixc/analyzer/methods/graph_step_validation.rs | 5/5 | Replaced four `panic!()` calls with proper E627 error generation for shortest path algorithms missing both from/to parameters |
| helix-db/src/helixc/analyzer/methods/statement_validation.rs | 5/5 | Replaced panic with E628 error when DROP is applied to non-traversal expressions |
| helix-db/src/helixc/parser/expression_parse_methods.rs | 5/5 | Replaced three `unreachable!()` macros with descriptive error messages for unexpected parser rules |
| helix-db/src/helixc/parser/graph_step_parse_methods.rs | 5/5 | Replaced four `unreachable!()` macros with proper ParserError for unexpected rules in order_by and shortest path parsing |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Parser
    participant Analyzer
    participant ErrorHandler
    
    Note over Parser,Analyzer: Before: panics on unexpected input
    
    User->>Parser: Submit HelixQL query
    
    alt Unexpected parse rule encountered
        Parser->>Parser: Match rule
        Parser-->>ErrorHandler: Return ParserError with context
        ErrorHandler-->>User: Descriptive error message
    end
    
    alt Valid parse, needs analysis
        Parser->>Analyzer: Pass parsed AST
        
        alt ShortestPath missing from/to
            Analyzer->>Analyzer: Validate graph step
            Analyzer-->>ErrorHandler: generate_error!(E627)
            ErrorHandler-->>User: "requires either `from` or `to` parameter"
        end
        
        alt DROP on non-traversal
            Analyzer->>Analyzer: Validate DROP statement
            Analyzer-->>ErrorHandler: generate_error!(E628)
            ErrorHandler-->>User: "DROP can only be applied to traversals"
        end
        
        alt Invalid field value type
            Analyzer->>Analyzer: Validate field values
            Analyzer-->>ErrorHandler: generate_error!(E206)
            ErrorHandler-->>User: "invalid value type"
        end
    end
    
    Note over Parser,ErrorHandler: After: graceful error handling
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->