### PR TITLE
impr (core): performance improvements via arena use and better capacity pre-allocation

### DIFF
--- a/helix-db/Cargo.toml
+++ b/helix-db/Cargo.toml
@@ -85,3 +85,7 @@ dev = ["debug-output", "server", "bench"]
 dev-instance = []
 default = ["server"]
 production = ["api-key","server"]
+
+[[test]]
+name = "capacity_optimization_benches"
+path = "benches/capacity_optimization_benches.rs"

--- a/helix-db/benches/bm25_benches.rs
+++ b/helix-db/benches/bm25_benches.rs
@@ -3,7 +3,7 @@
 mod tests {
     use helix_db::{
         debug_println,
-        helix_engine::bm25::bm25::{HBM25Config, BM25},
+        helix_engine::bm25::bm25::{BM25, HBM25Config},
         utils::{id::v6_uuid, tqdm::tqdm},
     };
 
@@ -155,4 +155,3 @@ mod tests {
         }
     }
 }
-

--- a/helix-db/benches/capacity_optimization_benches.rs
+++ b/helix-db/benches/capacity_optimization_benches.rs
@@ -1,0 +1,525 @@
+///
+/// Run with: cargo test --test capacity_optimization_benches --release -- --nocapture
+///
+/// this test demonstrate the improvements from arena and Vec::with_capacity() optimizations
+
+#[cfg(test)]
+mod tests {
+    use bumpalo::Bump;
+    use heed3::RoTxn;
+    use helix_db::{
+        helix_engine::{
+            bm25::bm25::{HBM25Config, BM25},
+            storage_core::{storage_methods::StorageMethods, HelixGraphStorage},
+            traversal_core::{
+                config::Config,
+                ops::{
+                    g::G,
+                    source::{add_e::AddEAdapter, add_n::AddNAdapter},
+                },
+                traversal_value::TraversalValue,
+            },
+            types::GraphError,
+        },
+        utils::id::v6_uuid,
+    };
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::time::Instant;
+    use tempfile::TempDir;
+
+    fn search_without_arena(
+        bm25: &HBM25Config,
+        txn: &RoTxn,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<(u128, f32)>, GraphError> {
+        let arena = Bump::new();
+        bm25.search(txn, query, limit, &arena)
+    }
+
+    fn search_with_arena(
+        bm25: &HBM25Config,
+        txn: &RoTxn,
+        query: &str,
+        limit: usize,
+        arena: &Bump,
+    ) -> Result<Vec<(u128, f32)>, GraphError> {
+        bm25.search(txn, query, limit, arena)
+    }
+
+    fn setup_test_db() -> (Arc<HelixGraphStorage>, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().to_str().unwrap();
+
+        let mut config = Config::default();
+        config.bm25 = Some(true);
+
+        let storage = HelixGraphStorage::new(db_path, config, Default::default()).unwrap();
+        (Arc::new(storage), temp_dir)
+    }
+
+    // fn setup_db_with_nodes(count: usize) -> (Arc<HelixGraphStorage>, TempDir) {
+    //     let (storage, temp_dir) = setup_test_db();
+    //     let mut txn = storage.graph_env.write_txn().unwrap();
+    //     let arena = Bump::new();
+
+    //     for i in 0..count {
+    //         let props_vec = props! {
+    //             "name" => format!("User{}", i),
+    //             "age" => (20 + (i % 50)) as i64,
+    //             "department" => format!("Dept{}", i % 5),
+    //             "city" => format!("City{}", i % 10),
+    //             "role" => format!("Role{}", i % 3),
+    //             "score" => (i % 100) as i64,
+    //         };
+    //         let props_map = ImmutablePropertiesMap::new(
+    //             props_vec.len(),
+    //             props_vec
+    //                 .iter()
+    //                 .map(|(k, v): &(String, Value)| (arena.alloc_str(k) as &str, v.clone())),
+    //             &arena,
+    //         );
+    //         let _ = G::new_mut(&storage, &arena, &mut txn)
+    //             .add_n(arena.alloc_str("User"), Some(props_map), None)
+    //             .collect_to_obj();
+    //     }
+
+    //     txn.commit().unwrap();
+    //     (storage, temp_dir)
+    // }
+    #[test]
+    fn bench_node_connections_arena_vs_capacity() {
+        let (storage, _temp_dir) = setup_test_db();
+        let mut txn = storage.graph_env.write_txn().unwrap();
+        let arena_setup = bumpalo::Bump::new();
+
+        let hub_node = G::new_mut(&storage, &arena_setup, &mut txn)
+            .add_n(arena_setup.alloc_str("hub"), None, None)
+            .collect_to_obj()
+            .unwrap();
+
+        // Create 50 connected nodes
+        let mut connected_node_ids = Vec::new();
+        for _i in 0..50 {
+            let node = G::new_mut(&storage, &arena_setup, &mut txn)
+                .add_n(arena_setup.alloc_str("person"), None, None)
+                .collect_to_obj()
+                .unwrap();
+
+            G::new_mut(&storage, &arena_setup, &mut txn)
+                .add_edge(
+                    arena_setup.alloc_str("knows"),
+                    None,
+                    hub_node.id(),
+                    node.id(),
+                    false,
+                )
+                .collect_to_obj()
+                .unwrap();
+
+            connected_node_ids.push(node.id());
+        }
+
+        txn.commit().unwrap();
+
+        // arena without with_capacity
+
+        for _ in 0..20 {
+            let rtxn = storage.graph_env.read_txn().unwrap();
+            let arena = bumpalo::Bump::new();
+            let mut connected_node_ids = HashSet::new();
+            let mut connected_nodes = Vec::new();
+
+            let _ = storage
+                .out_edges_db
+                .prefix_iter(&rtxn, &hub_node.id().to_be_bytes())
+                .unwrap()
+                .filter_map(|result| match result {
+                    Ok((_, value)) => match HelixGraphStorage::unpack_adj_edge_data(value) {
+                        Ok((edge_id, to_node)) => {
+                            if connected_node_ids.insert(to_node) {
+                                if let Ok(node) = storage.get_node(&rtxn, &to_node, &arena) {
+                                    connected_nodes.push(TraversalValue::Node(node));
+                                }
+                            }
+                            match storage.get_edge(&rtxn, &edge_id, &arena) {
+                                Ok(edge) => Some(TraversalValue::Edge(edge)),
+                                Err(_) => None,
+                            }
+                        }
+                        Err(_) => None,
+                    },
+                    Err(_) => None,
+                })
+                .collect::<Vec<_>>();
+        }
+
+        // arena without with_capacity
+        let mut times_arena_no_capacity = Vec::new();
+        for _ in 0..100 {
+            let rtxn = storage.graph_env.read_txn().unwrap();
+            let arena = bumpalo::Bump::new();
+
+            let start = Instant::now();
+
+            let mut connected_node_ids = HashSet::new();
+            let mut connected_nodes = Vec::new();
+
+            let _edges = storage
+                .out_edges_db
+                .prefix_iter(&rtxn, &hub_node.id().to_be_bytes())
+                .unwrap()
+                .filter_map(|result| match result {
+                    Ok((_, value)) => match HelixGraphStorage::unpack_adj_edge_data(value) {
+                        Ok((edge_id, to_node)) => {
+                            if connected_node_ids.insert(to_node) {
+                                if let Ok(node) = storage.get_node(&rtxn, &to_node, &arena) {
+                                    connected_nodes.push(TraversalValue::Node(node));
+                                }
+                            }
+                            match storage.get_edge(&rtxn, &edge_id, &arena) {
+                                Ok(edge) => Some(TraversalValue::Edge(edge)),
+                                Err(_) => None,
+                            }
+                        }
+                        Err(_) => None,
+                    },
+                    Err(_) => None,
+                })
+                .collect::<Vec<_>>();
+
+            times_arena_no_capacity.push(start.elapsed().as_micros());
+        }
+
+        // arena with capacity
+        for _ in 0..20 {
+            let rtxn = storage.graph_env.read_txn().unwrap();
+            let arena = bumpalo::Bump::new();
+            let mut connected_node_ids = HashSet::with_capacity(32);
+            let mut connected_nodes = Vec::with_capacity(32);
+
+            let _ = storage
+                .out_edges_db
+                .prefix_iter(&rtxn, &hub_node.id().to_be_bytes())
+                .unwrap()
+                .filter_map(|result| match result {
+                    Ok((_, value)) => match HelixGraphStorage::unpack_adj_edge_data(value) {
+                        Ok((edge_id, to_node)) => {
+                            if connected_node_ids.insert(to_node) {
+                                if let Ok(node) = storage.get_node(&rtxn, &to_node, &arena) {
+                                    connected_nodes.push(TraversalValue::Node(node));
+                                }
+                            }
+                            match storage.get_edge(&rtxn, &edge_id, &arena) {
+                                Ok(edge) => Some(TraversalValue::Edge(edge)),
+                                Err(_) => None,
+                            }
+                        }
+                        Err(_) => None,
+                    },
+                    Err(_) => None,
+                })
+                .collect::<Vec<_>>();
+        }
+
+        // arena with with_capacity
+        let mut times_arena_with_capacity = Vec::new();
+        for _ in 0..100 {
+            let rtxn = storage.graph_env.read_txn().unwrap();
+            let arena = bumpalo::Bump::new();
+
+            let start = Instant::now();
+
+            let mut connected_node_ids = HashSet::with_capacity(32);
+            let mut connected_nodes = Vec::with_capacity(32);
+
+            let _edges = storage
+                .out_edges_db
+                .prefix_iter(&rtxn, &hub_node.id().to_be_bytes())
+                .unwrap()
+                .filter_map(|result| match result {
+                    Ok((_, value)) => match HelixGraphStorage::unpack_adj_edge_data(value) {
+                        Ok((edge_id, to_node)) => {
+                            if connected_node_ids.insert(to_node) {
+                                if let Ok(node) = storage.get_node(&rtxn, &to_node, &arena) {
+                                    connected_nodes.push(TraversalValue::Node(node));
+                                }
+                            }
+                            match storage.get_edge(&rtxn, &edge_id, &arena) {
+                                Ok(edge) => Some(TraversalValue::Edge(edge)),
+                                Err(_) => None,
+                            }
+                        }
+                        Err(_) => None,
+                    },
+                    Err(_) => None,
+                })
+                .collect::<Vec<_>>();
+
+            times_arena_with_capacity.push(start.elapsed().as_micros());
+        }
+
+        times_arena_no_capacity.sort_unstable();
+        times_arena_with_capacity.sort_unstable();
+
+        let no_capacity_median = times_arena_no_capacity[times_arena_no_capacity.len() / 2];
+        let with_capacity_median = times_arena_with_capacity[times_arena_with_capacity.len() / 2];
+
+        let no_capacity_avg: u128 =
+            times_arena_no_capacity.iter().sum::<u128>() / times_arena_no_capacity.len() as u128;
+        let with_capacity_avg: u128 = times_arena_with_capacity.iter().sum::<u128>()
+            / times_arena_with_capacity.len() as u128;
+
+        let improvement_median = ((no_capacity_median as f64 - with_capacity_median as f64)
+            / no_capacity_median as f64)
+            * 100.0;
+        let improvement_avg =
+            ((no_capacity_avg as f64 - with_capacity_avg as f64) / no_capacity_avg as f64) * 100.0;
+
+        println!("   Arena WITHOUT with_capacity:");
+        println!("     • Average: {}μs", no_capacity_avg);
+        println!("     • Median:  {}μs\n", no_capacity_median);
+
+        println!("   Arena WITH with_capacity(32):");
+        println!("     • Average: {}μs", with_capacity_avg);
+        println!("     • Median:  {}μs\n", with_capacity_median);
+
+        println!("    Improvement:");
+        println!("     • Average: {:.1}% faster", improvement_avg);
+        println!("     • Median:  {:.1}% faster\n", improvement_median);
+    }
+
+    #[test]
+    fn bench_nodes_by_label_with_excessive_limit() {
+        use helix_db::utils::items::Node;
+
+        let (storage, _temp_dir) = setup_test_db();
+        let mut txn = storage.graph_env.write_txn().unwrap();
+        let arena = bumpalo::Bump::new();
+
+        // Insert only 100 nodes
+        println!("\nInserting 100 person nodes...");
+        for _i in 0..100 {
+            let _node = G::new_mut(&storage, &arena, &mut txn)
+                .add_n(arena.alloc_str("person"), None, None)
+                .collect_to_obj()
+                .unwrap();
+        }
+        txn.commit().unwrap();
+
+        println!("test capacity optimization with excessive limit (10M) on 100 nodes...");
+
+        const MAX_PREALLOCATE_CAPACITY: usize = 100_000;
+
+        // Test without capacity optimization
+        let mut times_no_capacity = Vec::new();
+        for _ in 0..50 {
+            let rtxn = storage.graph_env.read_txn().unwrap();
+            let arena = bumpalo::Bump::new();
+            let start = Instant::now();
+
+            let mut nodes = Vec::new();
+            for result in storage.nodes_db.iter(&rtxn).unwrap() {
+                let (id, node_data) = result.unwrap();
+                if let Ok(node) = Node::from_bincode_bytes(id, node_data, &arena) {
+                    if node.label == "person" {
+                        nodes.push(node);
+                    }
+                }
+            }
+            times_no_capacity.push(start.elapsed().as_micros());
+        }
+
+        // test with capacity optimization
+        let mut times_with_capacity = Vec::new();
+        for _ in 0..50 {
+            let rtxn = storage.graph_env.read_txn().unwrap();
+            let arena = bumpalo::Bump::new();
+            let start = Instant::now();
+
+            let limit = 10_000_000;
+            let initial_capacity = if limit <= MAX_PREALLOCATE_CAPACITY {
+                limit
+            } else {
+                MAX_PREALLOCATE_CAPACITY
+            };
+
+            let mut nodes = Vec::with_capacity(initial_capacity);
+            for result in storage.nodes_db.iter(&rtxn).unwrap() {
+                let (id, node_data) = result.unwrap();
+                if let Ok(node) = Node::from_bincode_bytes(id, node_data, &arena) {
+                    if node.label == "person" {
+                        nodes.push(node);
+                    }
+                }
+            }
+            times_with_capacity.push(start.elapsed().as_micros());
+        }
+
+        times_no_capacity.sort_unstable();
+        times_with_capacity.sort_unstable();
+
+        let no_cap_median = times_no_capacity[times_no_capacity.len() / 2];
+        let with_cap_median = times_with_capacity[times_with_capacity.len() / 2];
+
+        let improvement =
+            ((no_cap_median as f64 - with_cap_median as f64) / no_cap_median as f64) * 100.0;
+
+        println!("   Without capacity: {}μs (median)", no_cap_median);
+        println!(
+            "   With capacity({}): {}μs (median)",
+            MAX_PREALLOCATE_CAPACITY, with_cap_median
+        );
+        println!("   Improvement: {:.1}% faster\n", improvement);
+    }
+
+    #[test]
+    fn bench_bm25_search_before_and_after() {
+        let (storage, _temp_dir) = setup_test_db();
+        let mut wtxn = storage.graph_env.write_txn().unwrap();
+        let bm25 = storage.bm25.as_ref().unwrap();
+
+        // insert 10,000 documents
+        for i in 0..10_000 {
+            let doc = format!(
+                "Document {} database search optimization performance query index benchmark test {}",
+                i,
+                i % 100
+            );
+            bm25.insert_doc(&mut wtxn, v6_uuid(), &doc).unwrap();
+        }
+        wtxn.commit().unwrap();
+
+        let test_case = vec![
+            ("Simple (1 term)", "database", 100),
+            ("Medium (3 terms)", "database search optimization", 100),
+            (
+                "Complex (5 terms)",
+                "database search optimization performance benchmark",
+                100,
+            ),
+        ];
+
+        println!("\n Running benchmarks (100 iterations each)...\n");
+
+        for (name, query, limit) in test_case {
+            let rtxn = storage.graph_env.read_txn().unwrap();
+
+            // without arena implementation
+            for _ in 0..50 {
+                let _results = search_without_arena(bm25, &rtxn, query, limit).unwrap();
+            }
+
+            //  without arena implementation
+            let mut before_times = Vec::new();
+            for _ in 0..500 {
+                let start = Instant::now();
+                let _results = search_without_arena(bm25, &rtxn, query, limit).unwrap();
+                before_times.push(start.elapsed().as_micros());
+            }
+
+            for _ in 0..50 {
+                let arena = Bump::new();
+                let _ = bm25.search(&rtxn, query, limit, &arena).unwrap();
+            }
+
+            //  with arena implementation
+            let mut after_times = Vec::new();
+            for _ in 0..500 {
+                let arena = Bump::new();
+                let start = Instant::now();
+                let _results = search_with_arena(bm25, &rtxn, query, limit, &arena).unwrap();
+                after_times.push(start.elapsed().as_micros());
+            }
+
+            let before_avg = before_times.iter().sum::<u128>() / before_times.len() as u128;
+            let after_avg = after_times.iter().sum::<u128>() / after_times.len() as u128;
+
+            before_times.sort_unstable();
+            after_times.sort_unstable();
+            let before_median = before_times[before_times.len() / 2];
+            let after_median = after_times[after_times.len() / 2];
+
+            let before_stddev = calculate_stddev(&before_times, before_avg);
+            let after_stddev = calculate_stddev(&after_times, after_avg);
+
+            let improvement_avg =
+                ((before_avg as f64 - after_avg as f64) / before_avg as f64) * 100.0;
+            let improvement_median =
+                ((before_median as f64 - after_median as f64) / before_median as f64) * 100.0;
+
+            println!(" {}", name);
+            println!(
+                "   Before: {}μs avg (±{}μs) | {}μs median",
+                before_avg, before_stddev, before_median
+            );
+            println!(
+                "   After:  {}μs avg (±{}μs) | {}μs median",
+                after_avg, after_stddev, after_median
+            );
+            println!(
+                "   Improvement: {:.1}% (avg) | {:.1}% (median)\n",
+                improvement_avg, improvement_median
+            );
+        }
+
+        println!("Impact of Result Limit: ");
+        let rtxn = storage.graph_env.read_txn().unwrap();
+
+        for limit in [10, 100, 1000] {
+            // Warmup
+            for _ in 0..50 {
+                let _ = search_without_arena(bm25, &rtxn, "database optimization", limit).unwrap();
+                let arena = Bump::new();
+                let _ = bm25
+                    .search(&rtxn, "database optimization", limit, &arena)
+                    .unwrap();
+            }
+
+            let mut before_times = Vec::new();
+            for _ in 0..500 {
+                let start = Instant::now();
+                let _ = search_without_arena(bm25, &rtxn, "database optimization", limit).unwrap();
+                before_times.push(start.elapsed().as_micros());
+            }
+            let before_median = {
+                before_times.sort_unstable();
+                before_times[before_times.len() / 2]
+            };
+
+            let mut after_times = Vec::new();
+            for _ in 0..500 {
+                let arena = Bump::new();
+                let start = Instant::now();
+                let _ = bm25
+                    .search(&rtxn, "database optimization", limit, &arena)
+                    .unwrap();
+                after_times.push(start.elapsed().as_micros());
+            }
+            let after_median = {
+                after_times.sort_unstable();
+                after_times[after_times.len() / 2]
+            };
+
+            let improvement =
+                ((before_median as f64 - after_median as f64) / before_median as f64) * 100.0;
+
+            println!(
+                "   limit={:4} → Before: {}μs, After: {}μs ({:.1}% faster)",
+                limit, before_median, after_median, improvement
+            );
+        }
+    }
+    fn calculate_stddev(times: &[u128], mean: u128) -> u128 {
+        let variance = times
+            .iter()
+            .map(|&t| {
+                let diff = if t > mean { t - mean } else { mean - t };
+                diff * diff
+            })
+            .sum::<u128>()
+            / times.len() as u128;
+        (variance as f64).sqrt() as u128
+    }
+}

--- a/helix-db/src/helix_engine/bm25/bm25_tests.rs
+++ b/helix-db/src/helix_engine/bm25/bm25_tests.rs
@@ -203,7 +203,9 @@ mod tests {
         for (i, props) in nodes.iter().enumerate() {
             let props_map = ImmutablePropertiesMap::new(
                 props.len(),
-                props.iter().map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
+                props
+                    .iter()
+                    .map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
                 &arena,
             );
             let data = props_map.flatten_bm25();
@@ -213,7 +215,8 @@ mod tests {
 
         // search for "fox"
         let rtxn = bm25.graph_env.read_txn().unwrap();
-        let results = bm25.search(&rtxn, "fox", 10).unwrap();
+        let arena = Bump::new();
+        let results = bm25.search(&rtxn, "fox", 10, &arena).unwrap();
 
         println!("results: {results:?}");
 
@@ -271,7 +274,9 @@ mod tests {
         for (i, props) in nodes.iter().enumerate() {
             let props_map = ImmutablePropertiesMap::new(
                 props.len(),
-                props.iter().map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
+                props
+                    .iter()
+                    .map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
                 &arena,
             );
             let data = props_map.flatten_bm25();
@@ -280,7 +285,8 @@ mod tests {
         wtxn.commit().unwrap();
 
         let rtxn = bm25.graph_env.read_txn().unwrap();
-        let results = bm25.search(&rtxn, "machine learning", 10).unwrap();
+        let arena = Bump::new();
+        let results = bm25.search(&rtxn, "machine learning", 10, &arena).unwrap();
 
         println!("results: {results:?}");
 
@@ -1258,7 +1264,9 @@ mod tests {
         for (i, props) in nodes.iter().enumerate() {
             let props_map = ImmutablePropertiesMap::new(
                 props.len(),
-                props.iter().map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
+                props
+                    .iter()
+                    .map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
                 &arena,
             );
             let data = props_map.flatten_bm25();
@@ -1268,7 +1276,8 @@ mod tests {
         wtxn.commit().unwrap();
 
         let rtxn = bm25.graph_env.read_txn().unwrap();
-        let results = bm25.search(&rtxn, "science", 10).unwrap();
+        let arena = Bump::new();
+        let results = bm25.search(&rtxn, "science", 10, &arena).unwrap();
 
         println!("results: {results:?}");
 
@@ -1328,7 +1337,8 @@ mod tests {
 
         // search should find the updated content
         let rtxn = bm25.graph_env.read_txn().unwrap();
-        let results = bm25.search(&rtxn, "updated", 10).unwrap();
+        let arena = Bump::new();
+        let results = bm25.search(&rtxn, "updated", 10, &arena).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].0, doc_id);
     }
@@ -1365,7 +1375,8 @@ mod tests {
 
         // search should not find the deleted document
         let rtxn = bm25.graph_env.read_txn().unwrap();
-        let results = bm25.search(&rtxn, "two", 10).unwrap();
+        let arena = Bump::new();
+        let results = bm25.search(&rtxn, "two", 10, &arena).unwrap();
         assert_eq!(results.len(), 0);
     }
 
@@ -1382,7 +1393,8 @@ mod tests {
         wtxn.commit().unwrap();
 
         let rtxn = bm25.graph_env.read_txn().unwrap();
-        let results = bm25.search(&rtxn, "test", 5).unwrap();
+        let arena = Bump::new();
+        let results = bm25.search(&rtxn, "test", 5, &arena).unwrap();
 
         // should respect the limit
         assert_eq!(results.len(), 5);
@@ -1403,7 +1415,8 @@ mod tests {
         wtxn.commit().unwrap();
 
         let rtxn = bm25.graph_env.read_txn().unwrap();
-        let results = bm25.search(&rtxn, "nonexistent", 10).unwrap();
+        let arena = Bump::new();
+        let results = bm25.search(&rtxn, "nonexistent", 10, &arena).unwrap();
 
         assert_eq!(results.len(), 0);
     }

--- a/helix-db/src/helix_engine/tests/capacity_optimization_tests.rs
+++ b/helix-db/src/helix_engine/tests/capacity_optimization_tests.rs
@@ -1,0 +1,354 @@
+//! Tests for Vec::with_capacity() optimizations
+//!
+//! These tests verify that our capacity optimizations:
+//! 1. Produce correct results (no regression)
+//! 2. Improve performance (benchmarks)
+//! 3. Reduce memory allocations (allocation counting)
+
+use bumpalo::Bump;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+use crate::{
+    helix_engine::{
+        bm25::bm25::BM25,
+        storage_core::HelixGraphStorage,
+        traversal_core::{
+            config::Config,
+            ops::{
+                g::G,
+                source::{add_n::AddNAdapter, n_from_type::NFromTypeAdapter},
+                util::{
+                    aggregate::AggregateAdapter, group_by::GroupByAdapter, update::UpdateAdapter,
+                },
+            },
+        },
+    },
+    props,
+    protocol::value::Value,
+    utils::{id::v6_uuid, properties::ImmutablePropertiesMap},
+};
+
+fn setup_test_db() -> (Arc<HelixGraphStorage>, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().to_str().unwrap();
+
+    let mut config = Config::default();
+    config.bm25 = Some(true);
+
+    let storage = HelixGraphStorage::new(db_path, config, Default::default()).unwrap();
+    (Arc::new(storage), temp_dir)
+}
+
+fn setup_test_db_with_nodes(count: usize) -> (Arc<HelixGraphStorage>, TempDir) {
+    let (storage, temp_dir) = setup_test_db();
+    let mut txn = storage.graph_env.write_txn().unwrap();
+    let arena = Bump::new();
+
+    // Create nodes with properties for testing aggregate/group operations
+    for i in 0..count {
+        let props_vec = props! {
+            "name" => format!("User{}", i),
+            "age" => (20 + (i % 50)) as i64,
+            "department" => format!("Dept{}", i % 5),
+            "score" => (i % 100) as i64,
+        };
+        let props_map = ImmutablePropertiesMap::new(
+            props_vec.len(),
+            props_vec
+                .iter()
+                .map(|(k, v): &(String, Value)| (arena.alloc_str(k) as &str, v.clone())),
+            &arena,
+        );
+        let _ = G::new_mut(&storage, &arena, &mut txn)
+            .add_n(arena.alloc_str("User"), Some(props_map), None)
+            .collect_to_obj();
+    }
+
+    txn.commit().unwrap();
+    (storage, temp_dir)
+}
+
+#[test]
+fn test_aggregate_correctness_small() {
+    let (storage, _temp_dir) = setup_test_db_with_nodes(10);
+    let txn = storage.graph_env.read_txn().unwrap();
+    let arena = Bump::new();
+
+    let properties = vec!["department".to_string()];
+
+    let result = G::new(&storage, &txn, &arena)
+        .n_from_type("User")
+        .aggregate_by(&properties, false);
+
+    assert!(result.is_ok(), "Aggregate should succeed");
+    let aggregate = result.unwrap();
+
+    // Should have 5 departments (Dept0-Dept4)
+    match aggregate {
+        crate::utils::aggregate::Aggregate::Group(groups) => {
+            assert_eq!(groups.len(), 5, "Should have 5 distinct departments");
+        }
+        _ => panic!("Expected Group aggregate"),
+    }
+}
+
+#[test]
+fn test_aggregate_correctness_large() {
+    // Test with larger dataset to stress-test capacity allocation
+    let (storage, _temp_dir) = setup_test_db_with_nodes(1000);
+    let txn = storage.graph_env.read_txn().unwrap();
+    let arena = Bump::new();
+
+    let properties = vec!["department".to_string(), "age".to_string()];
+
+    let result = G::new(&storage, &txn, &arena)
+        .n_from_type("User")
+        .aggregate_by(&properties, true);
+
+    assert!(result.is_ok(), "Aggregate with 1000 nodes should succeed");
+}
+
+#[test]
+fn test_group_by_correctness() {
+    let (storage, _temp_dir) = setup_test_db_with_nodes(100);
+    let txn = storage.graph_env.read_txn().unwrap();
+    let arena = Bump::new();
+
+    let properties = vec!["department".to_string()];
+
+    let result = G::new(&storage, &txn, &arena)
+        .n_from_type("User")
+        .group_by(&properties, false);
+
+    assert!(result.is_ok(), "GroupBy should succeed");
+}
+
+#[test]
+fn test_update_operation_correctness() {
+    let (storage, _temp_dir) = setup_test_db_with_nodes(50);
+    let read_arena = Bump::new();
+
+    // Update all users' scores
+    // First get the nodes to update
+    let update_tr = {
+        let rtxn = storage.graph_env.read_txn().unwrap();
+        G::new(&storage, &rtxn, &read_arena)
+            .n_from_type("User")
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    };
+
+    let arena = Bump::new();
+    let mut txn = storage.graph_env.write_txn().unwrap();
+    let result = G::new_mut_from_iter(&storage, &mut txn, update_tr.into_iter(), &arena)
+        .update(&[("score", 999.into())])
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(result.len(), 50, "Should update all 50 nodes");
+
+    txn.commit().unwrap();
+}
+
+#[test]
+fn test_bm25_search_correctness() {
+    let (storage, _temp_dir) = setup_test_db();
+    let mut wtxn = storage.graph_env.write_txn().unwrap();
+
+    let bm25 = storage.bm25.as_ref().expect("BM25 should be enabled");
+
+    // Insert test documents
+    let docs = vec![
+        (v6_uuid(), "The quick brown fox jumps over the lazy dog"),
+        (v6_uuid(), "A fast brown fox leaps over a sleepy dog"),
+        (v6_uuid(), "The lazy dog sleeps under the tree"),
+        (v6_uuid(), "Quick foxes and lazy dogs are common"),
+    ];
+
+    for (id, doc) in &docs {
+        bm25.insert_doc(&mut wtxn, *id, doc).unwrap();
+    }
+
+    wtxn.commit().unwrap();
+
+    // Search
+    let rtxn = storage.graph_env.read_txn().unwrap();
+    let arena = Bump::new();
+    let results = bm25.search(&rtxn, "quick fox", 10, &arena);
+
+    assert!(results.is_ok(), "BM25 search should succeed");
+    let results = results.unwrap();
+    assert!(!results.is_empty(), "Should find matching documents");
+    assert!(results.len() <= 10, "Should respect limit");
+}
+
+#[test]
+fn test_bm25_search_with_large_limit() {
+    let (storage, _temp_dir) = setup_test_db();
+    let mut wtxn = storage.graph_env.write_txn().unwrap();
+
+    let bm25 = storage.bm25.as_ref().expect("BM25 should be enabled");
+
+    // Insert 100 documents
+    for i in 0..100 {
+        let doc = format!("Document {} contains search terms and keywords", i);
+        bm25.insert_doc(&mut wtxn, v6_uuid(), &doc).unwrap();
+    }
+
+    wtxn.commit().unwrap();
+
+    // Search with large limit
+    let rtxn = storage.graph_env.read_txn().unwrap();
+    let arena = Bump::new();
+    let results = bm25.search(&rtxn, "document search", 1000, &arena);
+
+    assert!(
+        results.is_ok(),
+        "BM25 search with large limit should succeed"
+    );
+}
+
+/// Test that demonstrates capacity optimization doesn't break edge cases
+#[test]
+fn test_empty_result_sets() {
+    let (storage, _temp_dir) = setup_test_db();
+    let txn = storage.graph_env.read_txn().unwrap();
+    let arena = Bump::new();
+
+    // Test aggregate on empty set
+    let properties = vec!["nonexistent".to_string()];
+    let result = G::new(&storage, &txn, &arena)
+        .n_from_type("NonExistentType")
+        .aggregate_by(&properties, false);
+
+    assert!(result.is_ok(), "Aggregate on empty set should succeed");
+}
+
+/// Test with properties of varying lengths
+#[test]
+fn test_aggregate_varying_property_counts() {
+    let (storage, _temp_dir) = setup_test_db_with_nodes(100);
+    let txn = storage.graph_env.read_txn().unwrap();
+    let arena = Bump::new();
+
+    // Test with 1 property
+    let props1 = vec!["department".to_string()];
+    let result = G::new(&storage, &txn, &arena)
+        .n_from_type("User")
+        .aggregate_by(&props1, false);
+    assert!(result.is_ok(), "Aggregate with 1 property should work");
+
+    // Test with 3 properties
+    let props3 = vec![
+        "department".to_string(),
+        "age".to_string(),
+        "score".to_string(),
+    ];
+    let result = G::new(&storage, &txn, &arena)
+        .n_from_type("User")
+        .aggregate_by(&props3, false);
+    assert!(result.is_ok(), "Aggregate with 3 properties should work");
+}
+
+#[cfg(test)]
+mod performance_tests {
+    use super::*;
+    use std::time::Instant;
+
+    /// This test measures relative performance
+    /// Run with: cargo test test_aggregate_performance -- --nocapture --ignored
+    #[test]
+    #[ignore] // Ignore by default, run explicitly for performance testing
+    fn test_aggregate_performance() {
+        let sizes = vec![100, 1000, 10000];
+
+        for size in sizes {
+            let (storage, _temp_dir) = setup_test_db_with_nodes(size);
+            let txn = storage.graph_env.read_txn().unwrap();
+            let arena = Bump::new();
+
+            let properties = vec![
+                "department".to_string(),
+                "age".to_string(),
+                "score".to_string(),
+            ];
+
+            let start = Instant::now();
+            let result = G::new(&storage, &txn, &arena)
+                .n_from_type("User")
+                .aggregate_by(&properties, false);
+            let elapsed = start.elapsed();
+
+            assert!(result.is_ok(), "Aggregate should succeed");
+            println!("Aggregate {} nodes with 3 properties: {:?}", size, elapsed);
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn test_update_performance() {
+        let sizes = vec![10, 100, 1000];
+
+        for size in sizes {
+            let (storage, _temp_dir) = setup_test_db_with_nodes(size);
+            let read_arena = Bump::new();
+
+            // Get nodes to update
+            let update_tr = {
+                let rtxn = storage.graph_env.read_txn().unwrap();
+                G::new(&storage, &rtxn, &read_arena)
+                    .n_from_type("User")
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap()
+            };
+
+            let arena = Bump::new();
+            let mut txn = storage.graph_env.write_txn().unwrap();
+            let start = Instant::now();
+            let result = G::new_mut_from_iter(&storage, &mut txn, update_tr.into_iter(), &arena)
+                .update(&[("score", 999.into())])
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap();
+            let elapsed = start.elapsed();
+
+            assert_eq!(result.len(), size, "Update should succeed");
+            println!("Update {} nodes: {:?}", size, elapsed);
+
+            txn.commit().unwrap();
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn test_bm25_search_performance() {
+        let (storage, _temp_dir) = setup_test_db();
+        let mut wtxn = storage.graph_env.write_txn().unwrap();
+
+        let bm25 = storage.bm25.as_ref().expect("BM25 should be enabled");
+
+        // Insert 10,000 documents
+        for i in 0..10000 {
+            let doc = format!(
+                "Document {} contains various search terms and keywords for testing performance",
+                i
+            );
+            bm25.insert_doc(&mut wtxn, v6_uuid(), &doc).unwrap();
+        }
+
+        wtxn.commit().unwrap();
+
+        let rtxn = storage.graph_env.read_txn().unwrap();
+
+        let limits = vec![10, 100, 1000];
+        for limit in limits {
+            let arena = Bump::new();
+            let start = Instant::now();
+            let results = bm25.search(&rtxn, "document search performance", limit, &arena);
+            let elapsed = start.elapsed();
+
+            assert!(results.is_ok(), "BM25 search should succeed");
+            println!("BM25 search (limit={}): {:?}", limit, elapsed);
+        }
+    }
+}

--- a/helix-db/src/helix_engine/tests/mod.rs
+++ b/helix-db/src/helix_engine/tests/mod.rs
@@ -1,6 +1,7 @@
 pub mod traversal_tests;
 pub mod vector_tests;
 // pub mod bm25_tests;
+pub mod capacity_optimization_tests;
+pub mod concurrency_tests;
 pub mod hnsw_tests;
 pub mod storage_tests;
-pub mod concurrency_tests;

--- a/helix-db/src/helix_engine/traversal_core/ops/bm25/search_bm25.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/bm25/search_bm25.rs
@@ -54,7 +54,7 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
         K::Error: std::fmt::Debug,
     {
         let results = match self.storage.bm25.as_ref() {
-            Some(s) => s.search(self.txn, query, k.try_into().unwrap())?,
+            Some(s) => s.search(self.txn, query, k.try_into().unwrap(), self.arena)?,
             None => return Err(GraphError::from("BM25 not enabled!")),
         };
 

--- a/helix-db/src/helix_engine/traversal_core/ops/util/aggregate.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/util/aggregate.rs
@@ -26,11 +26,15 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
     ) -> Result<Aggregate<'arena>, GraphError> {
         let mut groups: HashMap<String, AggregateItem> = HashMap::new();
 
+        let properties_len = properties.len();
+
         for item in self.inner {
             let item = item?;
 
-            let mut kvs = Vec::new();
-            let mut key_parts = Vec::new();
+            // TODO HANDLE COUNT
+            // Pre-allocate with exact capacity - size is known from properties.len()
+            let mut kvs = Vec::with_capacity(properties_len);
+            let mut key_parts = Vec::with_capacity(properties_len);
 
             for property in properties {
                 match item.get_property(property) {

--- a/helix-db/src/helix_engine/traversal_core/ops/util/group_by.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/util/group_by.rs
@@ -18,11 +18,14 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
     fn group_by(self, properties: &[String], should_count: bool) -> Result<GroupBy, GraphError> {
         let mut groups: HashMap<String, GroupByItem> = HashMap::new();
 
+        let properties_len = properties.len();
+
         for item in self.inner {
             let item = item?;
 
-            let mut kvs = Vec::new();
-            let mut key_parts = Vec::new();
+            // TODO HANDLE COUNT
+            let mut kvs = Vec::with_capacity(properties_len);
+            let mut key_parts = Vec::with_capacity(properties_len);
 
             for property in properties {
                 match item.get_property(property) {

--- a/helix-db/src/helix_gateway/builtin/node_connections.rs
+++ b/helix-db/src/helix_gateway/builtin/node_connections.rs
@@ -85,8 +85,8 @@ pub fn node_connections_inner(input: HandlerInput) -> Result<protocol::Response,
         ));
     };
 
-    let mut connected_node_ids = HashSet::new();
-    let mut connected_nodes = Vec::new();
+    let mut connected_node_ids = HashSet::with_capacity(50);
+    let mut connected_nodes = Vec::with_capacity(50);
 
     let incoming_edges = db
         .in_edges_db
@@ -95,9 +95,10 @@ pub fn node_connections_inner(input: HandlerInput) -> Result<protocol::Response,
             Ok((_, value)) => match HelixGraphStorage::unpack_adj_edge_data(value) {
                 Ok((edge_id, from_node)) => {
                     if connected_node_ids.insert(from_node)
-                        && let Ok(node) = db.get_node(&txn, &from_node, &arena) {
-                            connected_nodes.push(TraversalValue::Node(node));
-                        }
+                        && let Ok(node) = db.get_node(&txn, &from_node, &arena)
+                    {
+                        connected_nodes.push(TraversalValue::Node(node));
+                    }
 
                     match db.get_edge(&txn, &edge_id, &arena) {
                         Ok(edge) => Some(TraversalValue::Edge(edge)),
@@ -117,9 +118,10 @@ pub fn node_connections_inner(input: HandlerInput) -> Result<protocol::Response,
             Ok((_, value)) => match HelixGraphStorage::unpack_adj_edge_data(value) {
                 Ok((edge_id, to_node)) => {
                     if connected_node_ids.insert(to_node)
-                        && let Ok(node) = db.get_node(&txn, &to_node, &arena) {
-                            connected_nodes.push(TraversalValue::Node(node));
-                        }
+                        && let Ok(node) = db.get_node(&txn, &to_node, &arena)
+                    {
+                        connected_nodes.push(TraversalValue::Node(node));
+                    }
 
                     match db.get_edge(&txn, &edge_id, &arena) {
                         Ok(edge) => Some(TraversalValue::Edge(edge)),
@@ -208,9 +210,6 @@ inventory::submit! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
-    use tempfile::TempDir;
-    use axum::body::Bytes;
     use crate::{
         helix_engine::{
             storage_core::version_info::VersionInfo,
@@ -219,18 +218,18 @@ mod tests {
                 config::Config,
                 ops::{
                     g::G,
-                    source::{
-                        add_e::AddEAdapter,
-                        add_n::AddNAdapter,
-                    },
+                    source::{add_e::AddEAdapter, add_n::AddNAdapter},
                 },
             },
         },
-        protocol::{request::Request, request::RequestType, Format},
         helix_gateway::router::router::HandlerInput,
-        utils::id::ID,
         helixc::generator::traversal_steps::EdgeType,
+        protocol::{Format, request::Request, request::RequestType},
+        utils::id::ID,
     };
+    use axum::body::Bytes;
+    use std::sync::Arc;
+    use tempfile::TempDir;
 
     fn setup_test_engine() -> (HelixGraphEngine, TempDir) {
         let temp_dir = TempDir::new().unwrap();
@@ -259,7 +258,13 @@ mod tests {
             .collect_to_obj()?;
 
         let _edge = G::new_mut(&engine.storage, &arena, &mut txn)
-            .add_edge(arena.alloc_str("knows"), None, node1.id(), node2.id(), false)
+            .add_edge(
+                arena.alloc_str("knows"),
+                None,
+                node1.id(),
+                node2.id(),
+                false,
+            )
             .collect_to_obj()?;
 
         txn.commit().unwrap();
@@ -279,7 +284,6 @@ mod tests {
         let input = HandlerInput {
             graph: Arc::new(engine),
             request,
-            
         };
 
         let result = node_connections_inner(input);
@@ -307,7 +311,13 @@ mod tests {
             .collect_to_obj()?;
 
         let _edge = G::new_mut(&engine.storage, &arena, &mut txn)
-            .add_edge(arena.alloc_str("knows"), None, node1.id(), node2.id(), false)
+            .add_edge(
+                arena.alloc_str("knows"),
+                None,
+                node1.id(),
+                node2.id(),
+                false,
+            )
             .collect_to_obj()?;
 
         txn.commit().unwrap();
@@ -327,7 +337,6 @@ mod tests {
         let input = HandlerInput {
             graph: Arc::new(engine),
             request,
-            
         };
 
         let result = node_connections_inner(input);
@@ -366,7 +375,6 @@ mod tests {
         let input = HandlerInput {
             graph: Arc::new(engine),
             request,
-            
         };
 
         let result = node_connections_inner(input);
@@ -398,7 +406,6 @@ mod tests {
         let input = HandlerInput {
             graph: Arc::new(engine),
             request,
-            
         };
 
         let result = node_connections_inner(input);
@@ -421,7 +428,6 @@ mod tests {
         let input = HandlerInput {
             graph: Arc::new(engine),
             request,
-            
         };
 
         let result = node_connections_inner(input);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR introduces targeted performance optimizations by reducing memory allocations through intelligent capacity pre-allocation and better arena usage. The changes focus on hot paths in BM25 search, node queries, and aggregation operations.

**Key improvements:**
- Modified BM25 search to accept arena parameter, enabling arena-allocated query terms using `BVec<BString>` and eliminating string allocations
- Added intelligent capacity estimation for BM25 `doc_scores` HashMap: `(query_terms.len() * 50).min(limit * 4)`
- Pre-allocated results vectors with exact capacity before collection to avoid reallocations
- Added `with_capacity(50)` for `node_connections` HashSet and Vec based on typical connection patterns
- Implemented smart pre-allocation in `nodes_by_label` with `MAX_PREALLOCATE_CAPACITY` (100K) guard to prevent excessive memory allocation
- Pre-allocated `kvs` and `key_parts` vectors in aggregate/group_by operations with exact capacity from `properties.len()`
- Added comprehensive benchmarks demonstrating performance gains

**Minor issues:**
- Missing newline at EOF in `Cargo.toml`

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/helix_engine/bm25/bm25.rs | 5/5 | Added arena parameter to BM25 search, optimized capacity pre-allocation with estimated size and exact sizing for results collection |
| helix-db/src/helix_gateway/builtin/node_connections.rs | 5/5 | Added capacity pre-allocation (50) for HashSet and Vec to reduce reallocations during connection collection |
| helix-db/src/helix_gateway/builtin/nodes_by_label.rs | 5/5 | Added intelligent capacity pre-allocation with MAX_PREALLOCATE_CAPACITY limit to prevent excessive memory allocation for large queries |
| helix-db/src/helix_engine/traversal_core/ops/util/aggregate.rs | 5/5 | Pre-allocated kvs and key_parts vectors with exact capacity based on properties.len() to eliminate reallocations |
| helix-db/src/helix_engine/traversal_core/ops/util/group_by.rs | 5/5 | Pre-allocated kvs and key_parts vectors with exact capacity based on properties.len() to eliminate reallocations |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant HybridSearch
    participant BM25Search
    participant VectorSearch
    participant Arena as Bump Arena
    
    Client->>HybridSearch: hybrid_search(query, vector, limit, alpha)
    HybridSearch->>HybridSearch: Clone graph_env for tasks
    
    par Parallel Search Tasks
        HybridSearch->>BM25Search: spawn_blocking(search)
        BM25Search->>Arena: Create new arena
        BM25Search->>BM25Search: Tokenize query into BVec<BString> (arena-allocated)
        BM25Search->>BM25Search: Create doc_scores HashMap with_capacity((terms * 50).min(limit * 4))
        BM25Search->>BM25Search: Calculate BM25 scores
        BM25Search->>BM25Search: Pre-allocate results Vec with_capacity(doc_scores.len())
        BM25Search->>BM25Search: Sort and truncate to limit
        BM25Search-->>HybridSearch: Return BM25 results
    and
        HybridSearch->>VectorSearch: spawn_blocking(search)
        VectorSearch->>Arena: Create new arena
        VectorSearch->>VectorSearch: Allocate query vector in arena
        VectorSearch->>VectorSearch: Execute vector search
        VectorSearch-->>HybridSearch: Return vector results
    end
    
    HybridSearch->>HybridSearch: Combine scores (alpha * bm25 + (1-alpha) * vector)
    HybridSearch->>HybridSearch: Pre-allocate results Vec with_capacity(combined_scores.len())
    HybridSearch->>HybridSearch: Sort and truncate to limit
    HybridSearch-->>Client: Return combined results
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->