### PR TITLE
feat (cli): launching dashboard, updating versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "helix-cli"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "helix-db"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/helix-cli/Cargo.toml
+++ b/helix-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-cli"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 
 [dependencies]

--- a/helix-db/Cargo.toml
+++ b/helix-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-db"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2024"
 description = "HelixDB is a powerful, open-source, graph-vector database built in Rust for intelligent data storage for RAG and AI."
 license = "AGPL-3.0"


### PR DESCRIPTION
Release Notes: Dashboard CLI Command

  New Feature: helix dashboard

  A new CLI command has been added to launch and manage the Helix Dashboard directly from the terminal.

  Commands

  | Command                | Description                   |
  |------------------------|-------------------------------|
  | helix dashboard start  | Start the dashboard container |
  | helix dashboard stop   | Stop the running dashboard    |
  | helix dashboard status | Check dashboard status        |

  Features

  - Multiple Connection Modes
    - Direct mode: Connect to any Helix instance using --host <address>
    - Project mode: Automatically reads connection info from helix.toml
    - Default fallback: Connects to localhost:6969 when no config is found
  - Container Runtime Support
    - Works with both Docker and Podman
    - Automatic runtime detection
  - Cloud Integration
    - Seamlessly connects to cloud instances using existing authentication
    - Supports local and cloud deployments from project configuration
  - Developer Experience
    - Automatic browser opening when dashboard starts
    - Optional --attach flag to view container logs directly
    - --restart flag to force restart if already running

  Usage Examples

  # Start dashboard with auto-detected project settings
  helix dashboard start

  # Connect to a specific host
  helix dashboard start --host 192.168.1.100:6969

  # Start and attach to logs
  helix dashboard start --attach

  # Check if dashboard is running
  helix dashboard status

  # Stop the dashboard
  helix dashboard stop

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Version bump for `helix-cli` (2.1.3 → 2.1.4) and `helix-db` (1.1.3 → 1.1.4) following the addition of the dashboard CLI feature.

- **helix-cli**: Incremented to 2.1.4 to reflect the new `helix dashboard` command capabilities
- **helix-db**: Incremented to 1.1.4 to stay in sync with the CLI release
- **Cargo.lock**: Updated automatically to reflect the version changes

No issues found. This is a straightforward version bump with consistent changes across all affected files.

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| Cargo.lock | 5/5 | Lock file updated to reflect version bumps for helix-cli (2.1.3 → 2.1.4) and helix-db (1.1.3 → 1.1.4) |
| helix-cli/Cargo.toml | 5/5 | Version bump from 2.1.3 to 2.1.4 |
| helix-db/Cargo.toml | 5/5 | Version bump from 1.1.3 to 1.1.4 |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as helix-cli (2.1.4)
    participant DB as helix-db (2.1.4)
    
    Note over CLI,DB: Version Bump Release
    User->>CLI: helix dashboard start
    CLI->>CLI: Check container runtime (Docker/Podman)
    CLI->>CLI: Read helix.toml for connection config
    CLI->>DB: Connect to HelixDB instance
    DB-->>CLI: Connection established
    CLI-->>User: Dashboard launched
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->