### PR TITLE
Change to uploading template.tar.gz to s3 for cloud build

### DIFF
--- a/.github/workflows/s3_push.yml
+++ b/.github/workflows/s3_push.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Create and upload template.tar.gz
         run: |
           # Create tarball excluding .git and target directories
+          # Write to /tmp to avoid modifying the source directory during archiving
           tar -czvf /tmp/template.tar.gz \
-            --warning=no-file-changed \
             --exclude='.git' \
             --exclude='target' \
             .


### PR DESCRIPTION
## Description
Cloud building now uses a .tar.gz in S3 due to codebuild limitations.

Please test running it in this branch is possible, it's based off of main so should be no issues with building in the meantime.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Simplified S3 upload workflow by replacing multiple `aws s3 sync` commands with a single tarball upload to address CodeBuild limitations.

**Key Changes:**
- Created `template.tar.gz` containing entire repository (excluding `.git`, `target`, `*.tar.gz`)
- Changed S3 path from `s3://helix-repo/template/*` to `s3://helix-repo/template.tar.gz`
- Tarball now includes all repository files, not just the previously synced directories (`helix-cli/`, `helix-container/`, `helix-macros/`, `metrics/`, root Cargo files)

**Considerations:**
- Verify CodeBuild can extract and use the tarball correctly
- Consider adding exclusions for unnecessary directories (`assets/`, `helix-db/`, `hql-tests/`, `.github/`) to reduce tarball size if they're not needed for cloud builds

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/s3_push.yml | 4/5 | Simplified workflow to upload a single tarball instead of syncing multiple directories, excluding .git and target folders |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Repo as Repository
    participant AWS as AWS OIDC
    participant S3 as S3 Bucket

    Note over GH: Trigger: release/tag/manual
    
    GH->>Repo: Checkout repository
    Repo-->>GH: Repository contents
    
    GH->>AWS: Configure credentials (OIDC)
    AWS-->>GH: Temporary credentials
    
    GH->>GH: Create template.tar.gz<br/>(exclude .git, target, *.tar.gz)
    
    GH->>S3: Upload template.tar.gz
    S3-->>GH: Upload confirmation
    
    GH->>GH: Log success notification
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->