### PR TITLE
impr (core): implementing json error handling

### DIFF
--- a/helix-db/src/protocol/error.rs
+++ b/helix-db/src/protocol/error.rs
@@ -51,7 +51,7 @@ impl IntoResponse for HelixError {
         };
 
         let body = sonic_rs::to_vec(&error_response)
-            .unwrap_or_else(|_| format!(r#"{{"error":"{}","code":"UNKNOWN"}}"#, self).into_bytes());
+            .unwrap_or_else(|_| br#"{"error":"Internal serialization error","code":"INTERNAL_ERROR"}"#.to_vec());
 
         axum::response::Response::builder()
             .status(status)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Improved error handling by transforming plain text error responses into structured JSON format with machine-readable error codes.

- Added `ErrorResponse` struct with `error` message and `code` fields for consistent error format
- Implemented `code()` method to map each `HelixError` variant to a static error code (GRAPH_ERROR, VECTOR_ERROR, NOT_FOUND, INVALID_API_KEY)
- Enhanced `IntoResponse` implementation to serialize errors as JSON with `application/json` content-type header
- Added fallback handling for serialization failures using a hardcoded JSON byte string
- Updated tests to verify JSON content-type headers and added comprehensive error code tests

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/protocol/error.rs | 5/5 | Added structured JSON error responses with error codes and proper content-type headers, improved error handling with fallback for serialization failures |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant AxumHandler
    participant HelixError
    participant ErrorResponse
    participant sonic_rs
    participant Response

    Client->>AxumHandler: HTTP Request
    AxumHandler->>HelixError: Error occurs (Graph/Vector/NotFound/InvalidApiKey)
    HelixError->>HelixError: into_response() called
    HelixError->>HelixError: Determine HTTP status code (500/404/403)
    HelixError->>HelixError: Get error code via code() method
    HelixError->>ErrorResponse: Create ErrorResponse struct
    Note over ErrorResponse: {error: String, code: &'static str}
    ErrorResponse->>sonic_rs: to_vec(&error_response)
    alt Serialization succeeds
        sonic_rs-->>HelixError: Return JSON bytes
    else Serialization fails
        sonic_rs-->>HelixError: Return fallback JSON
        Note over HelixError: {"error":"Internal serialization error","code":"INTERNAL_ERROR"}
    end
    HelixError->>Response: Build response with status, Content-Type, and body
    Response-->>Client: HTTP Response with JSON error
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->