### PR TITLE
feat (cli): adding rust compilation error handling to helix build + push

### DIFF
--- a/helix-cli/src/docker.rs
+++ b/helix-cli/src/docker.rs
@@ -7,9 +7,39 @@ use crate::config::{BuildMode, ContainerRuntime, InstanceInfo};
 use crate::project::ProjectContext;
 use crate::utils::{print_confirm, print_status, print_warning};
 use eyre::{Result, eyre};
+use std::fmt;
 use std::process::{Command, Output};
 use std::thread;
 use std::time::Duration;
+
+/// Error type for Docker build failures that may be Rust compilation errors.
+#[derive(Debug)]
+pub enum DockerBuildError {
+    /// Rust compilation failed during Docker build
+    RustCompilation {
+        output: String,
+        instance_name: String,
+    },
+}
+
+impl fmt::Display for DockerBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DockerBuildError::RustCompilation { output, instance_name } => {
+                write!(f, "Rust compilation failed for instance '{}': {}", instance_name, output)
+            }
+        }
+    }
+}
+
+impl std::error::Error for DockerBuildError {}
+
+/// Check if Docker build output indicates a Rust compilation error.
+fn is_rust_compilation_error(output: &str) -> bool {
+    output.contains("error[E")
+        || output.contains("error: could not compile")
+        || (output.contains("cargo build") && output.contains("error:"))
+}
 
 pub struct DockerManager<'a> {
     project: &'a ProjectContext,
@@ -550,7 +580,19 @@ networks:
         let output = self.run_compose_command(instance_name, vec!["build"])?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let full_output = format!("{}\n{}", stderr, stdout);
+
+            // Check if this is a Rust compilation error
+            if is_rust_compilation_error(&full_output) {
+                return Err(DockerBuildError::RustCompilation {
+                    output: full_output,
+                    instance_name: instance_name.to_string(),
+                }
+                .into());
+            }
+
             return Err(eyre!("{} build failed:\n{stderr}", self.runtime.binary()));
         }
         print_status(self.runtime.label(), "Image built successfully");


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added Rust compilation error detection and GitHub issue creation flow to `helix build` command. When Docker builds fail due to Rust compilation errors (detected via patterns like `error[E` or `could not compile`), the CLI now prompts users to create a GitHub issue with filtered error output and `.hx` file contents.

Key changes:
- Created `DockerBuildError::RustCompilation` enum to distinguish Rust compilation failures from other Docker build errors
- Added `is_rust_compilation_error()` function to detect Rust errors in Docker output
- Implemented `handle_docker_rust_compilation_failure()` to guide users through GitHub issue creation
- Error handling properly stops spinner, offers issue creation, then propagates the original error

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-cli/src/docker.rs | 5/5 | Added `DockerBuildError` enum to detect and handle Rust compilation errors during Docker build |
| helix-cli/src/commands/build.rs | 5/5 | Added error handling for Docker build failures with GitHub issue creation flow for Rust compilation errors |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant BuildCmd as build.rs::run()
    participant Docker as DockerManager
    participant DockerBuild as docker compose build
    participant Handler as handle_docker_rust_compilation_failure()
    participant GitHub as GitHub Issue

    User->>BuildCmd: helix build
    BuildCmd->>Docker: build_image(instance_name)
    Docker->>DockerBuild: docker compose build
    
    alt Rust Compilation Succeeds
        DockerBuild-->>Docker: Success
        Docker-->>BuildCmd: Ok(())
        BuildCmd-->>User: Build successful
    else Rust Compilation Fails
        DockerBuild-->>Docker: Build failed with output
        Docker->>Docker: is_rust_compilation_error(output)
        Docker-->>BuildCmd: Err(DockerBuildError::RustCompilation)
        BuildCmd->>BuildCmd: downcast_ref::<DockerBuildError>()
        BuildCmd->>Handler: handle_docker_rust_compilation_failure(output, project)
        Handler->>Handler: filter_errors_only(docker_output)
        Handler->>Handler: collect_hx_contents(project)
        Handler->>User: print error message & confirm prompt
        User-->>Handler: User confirms
        Handler->>GitHub: GitHubIssueBuilder::new(cargo_errors).open_in_browser()
        GitHub-->>User: Opens browser with pre-filled issue
        Handler-->>BuildCmd: Ok(())
        BuildCmd-->>User: Err(e) - build failed
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->