### PR TITLE
[BUG] BM25 search queries return empty objects with zero UUIDs

### DIFF
--- a/helix-db/src/helix_engine/traversal_core/traversal_value.rs
+++ b/helix-db/src/helix_engine/traversal_core/traversal_value.rs
@@ -39,6 +39,7 @@ impl<'arena> TraversalValue<'arena> {
             TraversalValue::Edge(edge) => edge.id,
             TraversalValue::Vector(vector) => vector.id,
             TraversalValue::VectorNodeWithoutVectorData(vector) => vector.id,
+            TraversalValue::NodeWithScore { node, .. } => node.id,
             TraversalValue::Empty => 0,
             _ => 0,
         }
@@ -50,6 +51,7 @@ impl<'arena> TraversalValue<'arena> {
             TraversalValue::Edge(edge) => edge.label,
             TraversalValue::Vector(vector) => vector.label,
             TraversalValue::VectorNodeWithoutVectorData(vector) => vector.label,
+            TraversalValue::NodeWithScore { node, .. } => node.label,
             TraversalValue::Empty => "",
             _ => "",
         }
@@ -81,6 +83,7 @@ impl<'arena> TraversalValue<'arena> {
         match self {
             TraversalValue::Vector(vector) => vector.score(),
             TraversalValue::VectorNodeWithoutVectorData(_) => 2f64,
+            TraversalValue::NodeWithScore { score, .. } => *score,
             _ => unimplemented!(),
         }
     }
@@ -91,6 +94,7 @@ impl<'arena> TraversalValue<'arena> {
             TraversalValue::Edge(edge) => edge.label,
             TraversalValue::Vector(vector) => vector.label,
             TraversalValue::VectorNodeWithoutVectorData(vector) => vector.label,
+            TraversalValue::NodeWithScore { node, .. } => node.label,
             TraversalValue::Empty => "",
             _ => "",
         }
@@ -102,6 +106,7 @@ impl<'arena> TraversalValue<'arena> {
             TraversalValue::Edge(edge) => edge.get_property(property),
             TraversalValue::Vector(vector) => vector.get_property(property),
             TraversalValue::VectorNodeWithoutVectorData(vector) => vector.get_property(property),
+            TraversalValue::NodeWithScore { node, .. } => node.get_property(property),
             TraversalValue::Empty => None,
             _ => None,
         }
@@ -115,6 +120,7 @@ impl Hash for TraversalValue<'_> {
             TraversalValue::Edge(edge) => edge.id.hash(state),
             TraversalValue::Vector(vector) => vector.id.hash(state),
             TraversalValue::VectorNodeWithoutVectorData(vector) => vector.id.hash(state),
+            TraversalValue::NodeWithScore { node, .. } => node.id.hash(state),
             TraversalValue::Empty => state.write_u8(0),
             _ => state.write_u8(0),
         }
@@ -142,6 +148,10 @@ impl PartialEq for TraversalValue<'_> {
                 TraversalValue::VectorNodeWithoutVectorData(vector1),
                 TraversalValue::Vector(vector2),
             ) => vector1.id() == vector2.id(),
+            (
+                TraversalValue::NodeWithScore { node: n1, .. },
+                TraversalValue::NodeWithScore { node: n2, .. },
+            ) => n1.id == n2.id,
             (TraversalValue::Empty, TraversalValue::Empty) => true,
             _ => false,
         }


### PR DESCRIPTION
Fixes #758

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixes BM25 search returning empty objects by adding `NodeWithScore` variant handling to all `TraversalValue` accessor methods. Previously, the enum had the variant but core methods didn't handle it, causing default/empty values to be returned.

- Added `NodeWithScore` handling to `id()`, `label()`, `label_arena()`, `get_property()`, `score()` methods
- Updated `Hash` and `PartialEq` trait implementations to handle the variant
- BM25 search results now properly return node IDs, labels, properties, and scores

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/helix_engine/traversal_core/traversal_value.rs | 4/5 | Added NodeWithScore variant handling to all accessor methods (id, label, score, get_property) and trait implementations (Hash, PartialEq). Minor concern: PartialEq missing cross-variant comparisons between Node and NodeWithScore. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant BM25Search
    participant TraversalValue
    participant Node
    
    Client->>BM25Search: SearchImages query
    BM25Search->>BM25Search: Find matching nodes in index
    BM25Search->>Node: from_bincode_bytes(id, value, arena)
    Node-->>BM25Search: node with properties
    BM25Search->>TraversalValue: Create NodeWithScore { node, score }
    TraversalValue-->>BM25Search: NodeWithScore variant
    
    Note over Client,TraversalValue: Before fix: accessor methods returned default values
    
    Client->>TraversalValue: id()
    TraversalValue->>Node: Extract node.id
    Node-->>TraversalValue: u128 ID
    TraversalValue-->>Client: Proper UUID
    
    Client->>TraversalValue: get_property("Format")
    TraversalValue->>Node: node.get_property("Format")
    Node-->>TraversalValue: Property value
    TraversalValue-->>Client: Image properties
    
    Client->>TraversalValue: score()
    TraversalValue-->>Client: BM25 score
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->