### PR TITLE
Fix macos x86_64 runner

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -44,7 +44,7 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             binary_name: helix-aarch64-unknown-linux-gnu
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             binary_name: helix-x86_64-apple-darwin
           - os: macos-latest

--- a/.github/workflows/macos-x64-quickfix.yml
+++ b/.github/workflows/macos-x64-quickfix.yml
@@ -1,0 +1,45 @@
+name: Add macOS x64 Binary to Latest Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: macos-15-intel
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get latest release
+        id: latest_release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const release = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            core.setOutput('upload_url', release.data.upload_url);
+            core.setOutput('release_id', release.data.id);
+            console.log(`Found release: ${release.data.tag_name}`);
+
+      - name: Build
+        run: |
+          cd helix-cli
+          cargo build --release --target x86_64-apple-darwin
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.latest_release.outputs.upload_url }}
+          asset_path: target/x86_64-apple-darwin/release/helix
+          asset_name: helix-x86_64-apple-darwin
+          asset_content_type: application/octet-stream
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Update cli.yml to use macos-15 instead of deprecated macos-13 runners for x86_64-apple-darwin builds
- Add macos-x64-quickfix.yml workflow to manually upload the missing macOS x64 binary to the latest release

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Updated macOS runner from `macos-13` to `macos-15` and added quickfix workflow to upload missing x64 binary.

**Critical Issue:**
- `macos-15` runners use Apple Silicon (ARM64 architecture), not Intel x86_64. Building `x86_64-apple-darwin` targets on ARM64 runners will either fail or require cross-compilation setup with Rosetta 2
- Both `cli.yml` and `macos-x64-quickfix.yml` have this architecture mismatch

**Recommendation:**
- Use `macos-13` (if still available) or `macos-12` for native x86_64 builds
- If Intel runners are deprecated, implement proper cross-compilation with toolchain setup
- Test the build output to ensure x86_64 binaries work correctly on Intel Macs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/cli.yml | Updated runner from macos-13 to macos-15, but macos-15 is ARM64-based which may not properly build x86_64 targets |
| .github/workflows/macos-x64-quickfix.yml | New quickfix workflow to manually upload macOS x64 binary, but also uses macos-15 runner with same x86_64 compatibility concern |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Actions
    participant M15 as macos-15 Runner
    participant Cargo as Rust Cargo
    participant Release as GitHub Release
    
    Note over Dev,Release: Main CLI Workflow (cli.yml)
    Dev->>GH: Trigger workflow_dispatch
    GH->>GH: Create release
    GH->>M15: Start macos-15 runner
    Note over M15: ARM64 architecture
    M15->>Cargo: cargo build --target x86_64-apple-darwin
    Note over Cargo: ⚠️ Cross-compilation attempt<br/>ARM64 → x86_64
    Cargo-->>M15: Build result (may fail/incorrect)
    M15->>Release: Upload helix-x86_64-apple-darwin
    
    Note over Dev,Release: Quickfix Workflow (macos-x64-quickfix.yml)
    Dev->>GH: Manual workflow_dispatch
    GH->>M15: Start macos-15 runner
    M15->>Release: Get latest release info
    Release-->>M15: upload_url, release_id
    M15->>Cargo: cargo build --target x86_64-apple-darwin
    Note over Cargo: ⚠️ Same cross-compilation issue
    Cargo-->>M15: Build result
    M15->>Release: Upload binary to existing release
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->