### PR TITLE
fix macos x86_64 runner

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -44,7 +44,7 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             binary_name: helix-aarch64-unknown-linux-gnu
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             binary_name: helix-x86_64-apple-darwin
           - os: macos-latest

--- a/.github/workflows/macos-x64-quickfix.yml
+++ b/.github/workflows/macos-x64-quickfix.yml
@@ -1,0 +1,45 @@
+name: Add macOS x64 Binary to Latest Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: macos-15-intel
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get latest release
+        id: latest_release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const release = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            core.setOutput('upload_url', release.data.upload_url);
+            core.setOutput('release_id', release.data.id);
+            console.log(`Found release: ${release.data.tag_name}`);
+
+      - name: Build
+        run: |
+          cd helix-cli
+          cargo build --release --target x86_64-apple-darwin
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.latest_release.outputs.upload_url }}
+          asset_path: target/x86_64-apple-darwin/release/helix
+          asset_name: helix-x86_64-apple-darwin
+          asset_content_type: application/octet-stream
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Update cli.yml to use macos-15 instead of deprecated macos-13 runners
for x86_64-apple-darwin builds
- Add macos-x64-quickfix.yml workflow to manually upload the missing
macOS x64 binary to the latest release

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Updated GitHub Actions workflows to migrate from deprecated `macos-13` to macOS 15 runners and added a quickfix workflow for manually uploading missing binaries.

**Critical Issue Found:**
- Both workflows use `macos-15-intel` which is not a valid GitHub Actions runner identifier
- The correct runner for Intel x86_64 on macOS 15 is `macos-15-large`
- This will cause workflow failures when triggered

**Changes Made:**
- Replaced `macos-13` with `macos-15-intel` in the main CLI build matrix
- Created `macos-x64-quickfix.yml` workflow for manually uploading x64 binaries to existing releases

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/cli.yml | Updated macOS runner from `macos-13` to `macos-15-intel`, but the runner identifier is incorrect |
| .github/workflows/macos-x64-quickfix.yml | New workflow for manual x64 binary upload using incorrect runner identifier `macos-15-intel` |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant GHA as GitHub Actions
    participant Runner as macOS-15-large Runner
    participant Cargo as Rust Cargo
    participant Release as GitHub Release

    Note over User,Release: Main CLI Workflow (cli.yml)
    User->>GHA: Trigger workflow_dispatch
    GHA->>GHA: Create release job
    GHA->>Release: Create new release with tag
    Release-->>GHA: Return upload_url
    
    GHA->>Runner: Start build job (matrix)
    Runner->>Cargo: cargo build --release --target x86_64-apple-darwin
    Cargo-->>Runner: helix binary
    Runner->>Release: Upload helix-x86_64-apple-darwin
    
    Note over User,Release: Quickfix Workflow (macos-x64-quickfix.yml)
    User->>GHA: Manual workflow_dispatch
    GHA->>Release: Get latest release info
    Release-->>GHA: Return upload_url and release_id
    GHA->>Runner: Start build on macOS runner
    Runner->>Cargo: cargo build --release --target x86_64-apple-darwin
    Cargo-->>Runner: helix binary
    Runner->>Release: Upload helix-x86_64-apple-darwin to existing release
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->