### PR TITLE
Revert "updating tests to avoid concurrency bug"

### DIFF
--- a/.github/workflows/db_tests.yml
+++ b/.github/workflows/db_tests.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Run tests
       run: | 
         cd helix-db
-        cargo test --release --lib 
+        cargo test --release --lib -- --skip concurrency_tests

--- a/.github/workflows/dev_instance_tests.yml
+++ b/.github/workflows/dev_instance_tests.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Run dev instance tests
       run: | 
         cd helix-db
-        cargo test --release --lib --features dev-instance 
+        cargo test --release --lib --features dev-instance -- --skip concurrency_tests

--- a/.github/workflows/production_db_tests.yml
+++ b/.github/workflows/production_db_tests.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Run production tests
       run: |
         cd helix-db
-        cargo test --release --lib --features production
+        cargo test --release --lib --features production -- --skip concurrency_tests

--- a/helix-db/src/helix_engine/tests/concurrency_tests/hnsw_concurrent_tests.rs
+++ b/helix-db/src/helix_engine/tests/concurrency_tests/hnsw_concurrent_tests.rs
@@ -20,8 +20,8 @@ use std::sync::{Arc, Barrier};
 use std::thread;
 use tempfile::TempDir;
 
-use crate::helix_engine::storage_core::HelixGraphStorage;
 use crate::helix_engine::storage_core::version_info::VersionInfo;
+use crate::helix_engine::storage_core::HelixGraphStorage;
 use crate::helix_engine::traversal_core::config::Config;
 use crate::helix_engine::traversal_core::ops::g::G;
 use crate::helix_engine::traversal_core::ops::vectors::insert::InsertVAdapter;
@@ -31,15 +31,17 @@ use crate::helix_engine::vector_core::vector::HVector;
 type Filter = fn(&HVector, &RoTxn) -> bool;
 
 /// Setup storage for concurrent testing
-fn setup_concurrent_storage(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_concurrent_storage() -> (Arc<HelixGraphStorage>, TempDir) {
+    let temp_dir = tempfile::tempdir().unwrap();
     let path = temp_dir.path().to_str().unwrap();
 
-    let config = Config::default();
+    let mut config = Config::default();
+    config.db_max_size_gb = Some(1); // 1GB for concurrent testing
 
     let version_info = VersionInfo::default();
 
     let storage = HelixGraphStorage::new(path, config, version_info).unwrap();
-    Arc::new(storage)
+    (Arc::new(storage), temp_dir)
 }
 
 /// Generate a random vector of given dimensionality
@@ -58,8 +60,8 @@ fn test_concurrent_inserts_single_label() {
     // Multiple threads could race to set the entry point.
     //
     // EXPECTED: All inserts should succeed, graph should remain consistent
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+
+    let (storage, _temp_dir) = setup_concurrent_storage();
 
     let num_threads = 4;
     let vectors_per_thread = 25;
@@ -132,8 +134,7 @@ fn test_concurrent_searches_during_inserts() {
     // - Searches should return consistent results (no torn reads)
     // - Number of results should increase over time as inserts complete
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+    let (storage, _temp_dir) = setup_concurrent_storage();
 
     // Initialize with some initial vectors
     {
@@ -272,8 +273,7 @@ fn test_concurrent_inserts_multiple_labels() {
     //
     // EXPECTED: No contention between different labels, all inserts succeed
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+    let (storage, _temp_dir) = setup_concurrent_storage();
 
     let num_labels = 4;
     let vectors_per_label = 25;
@@ -357,8 +357,7 @@ fn test_entry_point_consistency() {
     //
     // EXPECTED: Entry point should always be a valid vector ID
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+    let (storage, _temp_dir) = setup_concurrent_storage();
 
     let num_threads = 8;
     let vectors_per_thread = 10;
@@ -415,9 +414,7 @@ fn test_entry_point_consistency() {
 
     // Verify results have valid properties
     for result in results.iter() {
-        if let crate::helix_engine::traversal_core::traversal_value::TraversalValue::Vector(v) =
-            result
-        {
+        if let crate::helix_engine::traversal_core::traversal_value::TraversalValue::Vector(v) = result {
             assert!(v.id > 0, "Result ID should be valid");
             assert!(!v.deleted, "Results should not be deleted");
             assert!(!v.data.is_empty(), "Results should have data");
@@ -433,8 +430,7 @@ fn test_graph_connectivity_after_concurrent_inserts() {
     // EXPECTED: Graph should remain connected (no orphaned nodes)
     // All vectors should be reachable from entry point
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+    let (storage, _temp_dir) = setup_concurrent_storage();
 
     let num_threads = 4;
     let vectors_per_thread = 20;
@@ -490,9 +486,7 @@ fn test_graph_connectivity_after_concurrent_inserts() {
 
         // All results should have valid distances
         for result in results {
-            if let crate::helix_engine::traversal_core::traversal_value::TraversalValue::Vector(v) =
-                result
-            {
+            if let crate::helix_engine::traversal_core::traversal_value::TraversalValue::Vector(v) = result {
                 assert!(
                     v.distance.is_some() && v.distance.unwrap() >= 0.0,
                     "Result should have valid distance"
@@ -509,8 +503,7 @@ fn test_transaction_isolation() {
     //
     // EXPECTED: Readers should see consistent snapshots even while writes occur
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+    let (storage, _temp_dir) = setup_concurrent_storage();
 
     // Initialize with known vectors
     let initial_count = 10;

--- a/helix-db/src/helix_engine/tests/concurrency_tests/integration_stress_tests.rs
+++ b/helix-db/src/helix_engine/tests/concurrency_tests/integration_stress_tests.rs
@@ -32,14 +32,15 @@ use crate::helix_engine::traversal_core::ops::source::{
 };
 
 /// Setup storage with appropriate configuration for stress testing
-fn setup_stress_storage(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_stress_storage() -> (Arc<HelixGraphStorage>, TempDir) {
+    let temp_dir = tempfile::tempdir().unwrap();
     let path = temp_dir.path().to_str().unwrap();
 
     let mut config = Config::default();
     config.db_max_size_gb = Some(20); // Large size for stress tests
 
     let storage = HelixGraphStorage::new(path, config, Default::default()).unwrap();
-    Arc::new(storage)
+    (Arc::new(storage), temp_dir)
 }
 
 #[test]
@@ -49,8 +50,7 @@ fn test_stress_mixed_read_write_operations() {
     //
     // EXPECTED: Both operations function correctly under load
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_stress_storage(&temp_dir);
+    let (storage, _temp_dir) = setup_stress_storage();
 
     let duration = Duration::from_secs(3);
     let start = std::time::Instant::now();
@@ -144,8 +144,7 @@ fn test_stress_rapid_graph_growth() {
     //
     // EXPECTED: Graph remains traversable and consistent
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_stress_storage(&temp_dir);
+    let (storage, _temp_dir) = setup_stress_storage();
 
     // Create root nodes
     let root_ids: Vec<u128> = {
@@ -277,8 +276,7 @@ fn test_stress_transaction_contention() {
     //
     // EXPECTED: LMDB single-writer enforced, no corruption
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_stress_storage(&temp_dir);
+    let (storage, _temp_dir) = setup_stress_storage();
 
     let num_threads = 8;
     let duration = Duration::from_secs(2);
@@ -352,8 +350,7 @@ fn test_stress_long_running_transactions() {
     //
     // EXPECTED: MVCC snapshot isolation maintained, no blocking
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_stress_storage(&temp_dir);
+    let (storage, _temp_dir) = setup_stress_storage();
 
     // Create initial data
     {
@@ -448,8 +445,7 @@ fn test_stress_memory_stability() {
     //
     // EXPECTED: System remains stable, no unbounded growth
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_stress_storage(&temp_dir);
+    let (storage, _temp_dir) = setup_stress_storage();
 
     let duration = Duration::from_secs(3);
     let iterations = 3;

--- a/helix-db/src/helix_engine/tests/concurrency_tests/traversal_concurrent_tests.rs
+++ b/helix-db/src/helix_engine/tests/concurrency_tests/traversal_concurrent_tests.rs
@@ -32,14 +32,15 @@ use crate::helix_engine::traversal_core::ops::out::out::OutAdapter;
 use crate::helix_engine::traversal_core::ops::in_::in_::InAdapter;
 
 /// Setup storage for concurrent testing
-fn setup_concurrent_storage(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_concurrent_storage() -> (TempDir, Arc<HelixGraphStorage>) {
+    let temp_dir = tempfile::tempdir().unwrap();
     let path = temp_dir.path().to_str().unwrap();
 
     let mut config = Config::default();
     config.db_max_size_gb = Some(10);
 
     let storage = HelixGraphStorage::new(path, config, Default::default()).unwrap();
-    Arc::new(storage)
+    (temp_dir, Arc::new(storage))
 }
 
 #[test]
@@ -49,8 +50,7 @@ fn test_concurrent_node_additions() {
     //
     // EXPECTED: All nodes created successfully, no ID collisions
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+    let (_temp_dir, storage) = setup_concurrent_storage();
 
     let num_threads = 4;
     let nodes_per_thread = 25;
@@ -103,8 +103,7 @@ fn test_concurrent_edge_additions() {
     //
     // EXPECTED: All edges created, proper serialization
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+    let (_temp_dir, storage) = setup_concurrent_storage();
 
     // Create nodes first
     let node_ids: Vec<u128> = {
@@ -180,8 +179,7 @@ fn test_concurrent_reads_during_writes() {
     //
     // EXPECTED: Readers see consistent snapshots (MVCC)
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+    let (_temp_dir, storage) = setup_concurrent_storage();
 
     // Create initial graph structure
     let root_id = {
@@ -311,8 +309,7 @@ fn test_traversal_snapshot_isolation() {
     //
     // EXPECTED: Traversal results don't change during transaction lifetime
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+    let (_temp_dir, storage) = setup_concurrent_storage();
 
     // Create initial graph
     let root_id = {
@@ -407,8 +404,7 @@ fn test_concurrent_bidirectional_traversals() {
     //
     // EXPECTED: Both directions remain consistent
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+    let (_temp_dir, storage) = setup_concurrent_storage();
 
     // Create bidirectional graph structure
     let (source_ids, target_ids) = {
@@ -505,8 +501,7 @@ fn test_concurrent_multi_hop_traversals() {
     //
     // EXPECTED: Multi-hop paths remain consistent
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+    let (_temp_dir, storage) = setup_concurrent_storage();
 
     // Create chain: root -> level1 nodes -> level2 nodes
     let root_id = {
@@ -604,8 +599,7 @@ fn test_concurrent_graph_topology_consistency() {
     //
     // EXPECTED: No broken edges, all edges point to valid nodes
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+    let (_temp_dir, storage) = setup_concurrent_storage();
 
     let num_writers = 4;
     let nodes_per_writer = 10;
@@ -691,8 +685,7 @@ fn test_stress_concurrent_mixed_operations() {
     //
     // EXPECTED: No panics, deadlocks, or corruption
 
-    let temp_dir = tempfile::tempdir().unwrap();
-    let storage = setup_concurrent_storage(&temp_dir);
+    let (_temp_dir, storage) = setup_concurrent_storage();
 
     // Create initial graph
     let root_ids: Vec<u128> = {

--- a/helix-db/src/helix_engine/tests/traversal_tests/count_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/count_tests.rs
@@ -22,7 +22,8 @@ use crate::{
 use rand::Rng;
 use tempfile::TempDir;
 use bumpalo::Bump;
-fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_test_db() -> (TempDir, Arc<HelixGraphStorage>) {
+    let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().to_str().unwrap();
     let storage = HelixGraphStorage::new(
         db_path,
@@ -30,13 +31,12 @@ fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
         Default::default(),
     )
     .unwrap();
-    Arc::new(storage)
+    (temp_dir, Arc::new(storage))
 }
 
 #[test]
 fn test_count_single_node() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
     let person = G::new_mut(&storage, &arena, &mut txn)
@@ -54,8 +54,7 @@ fn test_count_single_node() {
 
 #[test]
 fn test_count_node_array() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
     let _ = G::new_mut(&storage, &arena, &mut txn)
@@ -78,8 +77,7 @@ fn test_count_node_array() {
 
 #[test]
 fn test_count_mixed_steps() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -129,8 +127,7 @@ fn test_count_mixed_steps() {
 
 #[test]
 fn test_count_empty() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let txn = storage.graph_env.read_txn().unwrap();
     let count = G::new(&storage, &txn, &arena)
@@ -143,8 +140,7 @@ fn test_count_empty() {
 
 #[test]
 fn test_count_filter_ref() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 

--- a/helix-db/src/helix_engine/tests/traversal_tests/drop_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/drop_tests.rs
@@ -32,7 +32,8 @@ use crate::{
 
 type Filter = fn(&HVector, &RoTxn) -> bool;
 
-fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_test_db() -> (TempDir, Arc<HelixGraphStorage>) {
+    let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().to_str().unwrap();
     let storage = HelixGraphStorage::new(
         db_path,
@@ -40,7 +41,7 @@ fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
         Default::default(),
     )
     .unwrap();
-    Arc::new(storage)
+    (temp_dir, Arc::new(storage))
 }
 
 fn to_result_iter(
@@ -65,8 +66,7 @@ fn edge_id(value: TraversalValue) -> u128 {
 
 #[test]
 fn test_drop_edge() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -126,8 +126,7 @@ fn test_drop_edge() {
 
 #[test]
 fn test_drop_node() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -171,16 +170,14 @@ fn test_drop_node() {
     let edges = G::new(&storage, &txn, &arena)
         .n_from_id(&node2_id)
         .in_e("knows")
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
+        .collect::<Result<Vec<_>, _>>().unwrap();
     println!("edges: {:?}", edges);
     assert!(edges.is_empty());
 }
 
 #[test]
 fn test_drop_traversal() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -240,8 +237,7 @@ fn test_drop_traversal() {
 
 #[test]
 fn test_node_deletion_in_existing_graph() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -325,8 +321,7 @@ fn test_node_deletion_in_existing_graph() {
 
 #[test]
 fn test_edge_deletion_in_existing_graph() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -381,8 +376,7 @@ fn test_edge_deletion_in_existing_graph() {
 
 #[test]
 fn test_vector_deletion_in_existing_graph() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 

--- a/helix-db/src/helix_engine/tests/traversal_tests/edge_traversal_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/edge_traversal_tests.rs
@@ -31,7 +31,8 @@ use heed3::RoTxn;
 
 type Filter = fn(&HVector, &RoTxn) -> bool;
 
-fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_test_db() -> (TempDir, Arc<HelixGraphStorage>) {
+    let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().to_str().unwrap();
     let storage = HelixGraphStorage::new(
         db_path,
@@ -39,7 +40,7 @@ fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
         Default::default(),
     )
     .unwrap();
-    Arc::new(storage)
+    (temp_dir, Arc::new(storage))
 }
 
 fn edge_id(value: &TraversalValue) -> u128 {
@@ -51,8 +52,7 @@ fn edge_id(value: &TraversalValue) -> u128 {
 
 #[test]
 fn test_add_edge_creates_relationship() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -81,8 +81,7 @@ fn test_add_edge_creates_relationship() {
 
 #[test]
 fn test_out_e_returns_edge() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -111,8 +110,7 @@ fn test_out_e_returns_edge() {
 
 #[test]
 fn test_in_e_returns_edge() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -141,8 +139,7 @@ fn test_in_e_returns_edge() {
 
 #[test]
 fn test_out_node_returns_neighbor() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -171,8 +168,7 @@ fn test_out_node_returns_neighbor() {
 
 #[test]
 fn test_edge_properties_can_be_read() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -214,8 +210,7 @@ fn test_edge_properties_can_be_read() {
 
 #[test]
 fn test_vector_edges_roundtrip() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -256,8 +251,7 @@ fn test_vector_edges_roundtrip() {
 
 #[test]
 fn test_e_from_id_with_nonexistent_id() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let txn = storage.graph_env.read_txn().unwrap();
 
@@ -275,8 +269,7 @@ fn test_e_from_id_with_nonexistent_id() {
 
 #[test]
 fn test_e_from_id_with_deleted_edge() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -331,8 +324,7 @@ fn test_e_from_id_with_deleted_edge() {
 
 #[test]
 fn test_e_from_id_with_zero_id() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let txn = storage.graph_env.read_txn().unwrap();
 
@@ -347,8 +339,7 @@ fn test_e_from_id_with_zero_id() {
 
 #[test]
 fn test_e_from_id_with_max_id() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let txn = storage.graph_env.read_txn().unwrap();
 

--- a/helix-db/src/helix_engine/tests/traversal_tests/filter_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/filter_tests.rs
@@ -18,7 +18,8 @@ use crate::{
 use bumpalo::Bump;
 use tempfile::TempDir;
 
-fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_test_db() -> (TempDir, Arc<HelixGraphStorage>) {
+    let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().to_str().unwrap();
     let storage = HelixGraphStorage::new(
         db_path,
@@ -26,13 +27,12 @@ fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
         Default::default(),
     )
     .unwrap();
-    Arc::new(storage)
+    (temp_dir, Arc::new(storage))
 }
 
 #[test]
 fn test_filter_nodes() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -74,8 +74,7 @@ fn test_filter_nodes() {
 
 #[test]
 fn test_filter_macro_single_argument() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -126,8 +125,7 @@ fn test_filter_macro_single_argument() {
 
 #[test]
 fn test_filter_macro_multiple_arguments() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -170,8 +168,7 @@ fn test_filter_macro_multiple_arguments() {
 
 #[test]
 fn test_filter_edges() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -234,8 +231,7 @@ fn test_filter_edges() {
 
 #[test]
 fn test_filter_empty_result() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -268,8 +264,7 @@ fn test_filter_empty_result() {
 
 #[test]
 fn test_filter_chain() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 

--- a/helix-db/src/helix_engine/tests/traversal_tests/node_traversal_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/node_traversal_tests.rs
@@ -27,7 +27,8 @@ use crate::{
 use bumpalo::Bump;
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
-fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_test_db() -> (TempDir, Arc<HelixGraphStorage>) {
+    let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().to_str().unwrap();
     let storage = HelixGraphStorage::new(
         db_path,
@@ -35,13 +36,12 @@ fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
         Default::default(),
     )
     .unwrap();
-    Arc::new(storage)
+    (temp_dir, Arc::new(storage))
 }
 
 #[test]
 fn test_add_n() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
 
     let mut txn = storage.graph_env.write_txn().unwrap();
@@ -81,8 +81,7 @@ fn test_add_n() {
 
 #[test]
 fn test_out() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -124,8 +123,7 @@ fn test_out() {
 
 #[test]
 fn test_in() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -157,8 +155,7 @@ fn test_in() {
 
 #[test]
 fn test_complex_traversal() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -228,8 +225,7 @@ fn test_complex_traversal() {
 
 #[test]
 fn test_n_from_id() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -250,8 +246,7 @@ fn test_n_from_id() {
 
 #[test]
 fn test_n_from_id_with_traversal() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -281,8 +276,7 @@ fn test_n_from_id_with_traversal() {
 #[test]
 #[should_panic]
 fn test_n_from_id_nonexistent() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let txn = storage.graph_env.read_txn().unwrap();
     G::new(&storage, &txn, &arena)
@@ -292,8 +286,7 @@ fn test_n_from_id_nonexistent() {
 
 #[test]
 fn test_n_from_id_chain_operations() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -333,8 +326,7 @@ fn test_n_from_id_chain_operations() {
 
 #[test]
 fn test_with_id_type() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -371,8 +363,7 @@ fn test_with_id_type() {
 
 #[test]
 fn test_double_add_and_double_fetch() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let db = &*storage;
     let arena = Bump::new();
     let mut txn = db.graph_env.write_txn().unwrap();
@@ -459,8 +450,7 @@ fn test_double_add_and_double_fetch() {
 
 #[test]
 fn test_n_from_id_with_nonexistent_id() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let txn = storage.graph_env.read_txn().unwrap();
 
@@ -478,8 +468,7 @@ fn test_n_from_id_with_nonexistent_id() {
 
 #[test]
 fn test_n_from_id_with_deleted_node() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -523,8 +512,7 @@ fn test_n_from_id_with_deleted_node() {
 
 #[test]
 fn test_n_from_id_with_zero_id() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let txn = storage.graph_env.read_txn().unwrap();
 
@@ -539,8 +527,7 @@ fn test_n_from_id_with_zero_id() {
 
 #[test]
 fn test_n_from_id_with_max_id() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let txn = storage.graph_env.read_txn().unwrap();
 

--- a/helix-db/src/helix_engine/tests/traversal_tests/range_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/range_tests.rs
@@ -22,7 +22,8 @@ use crate::{
     props,
 };
 
-fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_test_db() -> (TempDir, Arc<HelixGraphStorage>) {
+    let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().to_str().unwrap();
     let storage = HelixGraphStorage::new(
         db_path,
@@ -30,13 +31,12 @@ fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
         Default::default(),
     )
     .unwrap();
-    Arc::new(storage)
+    (temp_dir, Arc::new(storage))
 }
 
 #[test]
 fn test_range_subset() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -63,8 +63,7 @@ fn test_range_subset() {
 
 #[test]
 fn test_range_chaining() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -115,8 +114,7 @@ fn test_range_chaining() {
 
 #[test]
 fn test_range_empty() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
 
     let txn = storage.graph_env.read_txn().unwrap();

--- a/helix-db/src/helix_engine/tests/traversal_tests/secondary_index_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/secondary_index_tests.rs
@@ -23,12 +23,13 @@ use crate::{
     protocol::value::Value,
 };
 
-fn setup_indexed_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_indexed_db() -> (TempDir, Arc<HelixGraphStorage>) {
+    let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().to_str().unwrap();
     let mut config = crate::helix_engine::traversal_core::config::Config::default();
     config.graph_config.as_mut().unwrap().secondary_indices = Some(vec!["name".to_string()]);
     let storage = HelixGraphStorage::new(db_path, config, Default::default()).unwrap();
-    Arc::new(storage)
+    (temp_dir, Arc::new(storage))
 }
 
 fn to_result_iter(
@@ -39,8 +40,7 @@ fn to_result_iter(
 
 #[test]
 fn test_delete_node_with_secondary_index() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_indexed_db(&temp_dir);
+    let (_temp_dir, storage) = setup_indexed_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -93,8 +93,7 @@ fn test_delete_node_with_secondary_index() {
 
 #[test]
 fn test_update_of_secondary_indices() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_indexed_db(&temp_dir);
+    let (_temp_dir, storage) = setup_indexed_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 

--- a/helix-db/src/helix_engine/tests/traversal_tests/shortest_path_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/shortest_path_tests.rs
@@ -19,7 +19,8 @@ use crate::{
     props,
 };
 
-fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_test_db() -> (TempDir, Arc<HelixGraphStorage>) {
+    let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().to_str().unwrap();
     let storage = HelixGraphStorage::new(
         db_path,
@@ -27,13 +28,12 @@ fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
         Default::default(),
     )
     .unwrap();
-    Arc::new(storage)
+    (temp_dir, Arc::new(storage))
 }
 
 #[test]
 fn test_shortest_path_simple_chain() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -80,8 +80,7 @@ fn test_shortest_path_simple_chain() {
 
 #[test]
 fn test_dijkstra_shortest_path_weighted_graph() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -193,8 +192,7 @@ fn test_dijkstra_shortest_path_weighted_graph() {
 fn test_dijkstra_custom_weight_function() {
     use crate::protocol::value::Value;
 
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -299,8 +297,7 @@ fn test_dijkstra_custom_weight_function() {
 fn test_dijkstra_multi_context_weight() {
     use crate::protocol::value::Value;
 
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -519,8 +516,7 @@ fn test_default_weight_fn_unit() {
 
 #[test]
 fn test_shortest_path_with_constant_weight() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -593,8 +589,7 @@ fn test_shortest_path_with_constant_weight() {
 fn test_astar_with_property_heuristic() {
     use crate::helix_engine::traversal_core::ops::util::paths::property_heuristic;
 
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -727,8 +722,7 @@ fn test_astar_with_property_heuristic() {
 
 #[test]
 fn test_astar_matches_dijkstra_with_zero_heuristic() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -836,8 +830,7 @@ fn test_astar_matches_dijkstra_with_zero_heuristic() {
 fn test_astar_custom_weight_and_heuristic() {
     use crate::helix_engine::traversal_core::ops::util::paths::property_heuristic;
 
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 

--- a/helix-db/src/helix_engine/tests/traversal_tests/update_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/update_tests.rs
@@ -20,7 +20,8 @@ use crate::{
     props,
 };
 
-fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_test_db() -> (TempDir, Arc<HelixGraphStorage>) {
+    let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().to_str().unwrap();
     let storage = HelixGraphStorage::new(
         db_path,
@@ -28,13 +29,12 @@ fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
         Default::default(),
     )
     .unwrap();
-    Arc::new(storage)
+    (temp_dir, Arc::new(storage))
 }
 
 #[test]
 fn test_update_node() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 

--- a/helix-db/src/helix_engine/tests/traversal_tests/util_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/util_tests.rs
@@ -25,7 +25,8 @@ use crate::{
 use heed3::RoTxn;
 use tempfile::TempDir;
 use bumpalo::Bump;
-fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_test_db() -> (TempDir, Arc<HelixGraphStorage>) {
+    let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().to_str().unwrap();
     let storage = HelixGraphStorage::new(
         db_path,
@@ -33,13 +34,12 @@ fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
         Default::default(),
     )
     .unwrap();
-    Arc::new(storage)
+    (temp_dir, Arc::new(storage))
 }
 
 #[test]
 fn test_order_node_by_asc() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -71,8 +71,7 @@ fn test_order_node_by_asc() {
 
 #[test]
 fn test_order_node_by_desc() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -104,8 +103,7 @@ fn test_order_node_by_desc() {
 
 #[test]
 fn test_order_edge_by_asc() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -157,8 +155,7 @@ fn test_order_edge_by_asc() {
 
 #[test]
 fn test_order_edge_by_desc() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -210,8 +207,7 @@ fn test_order_edge_by_desc() {
 
 #[test]
 fn test_order_vector_by_asc() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
     type FnTy = fn(&HVector, &RoTxn) -> bool;
@@ -244,8 +240,7 @@ fn test_order_vector_by_asc() {
 
 #[test]
 fn test_order_vector_by_desc() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
     type FnTy = fn(&HVector, &RoTxn) -> bool;
@@ -278,8 +273,7 @@ fn test_order_vector_by_desc() {
 
 #[test]
 fn test_dedup() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 

--- a/helix-db/src/helix_engine/tests/traversal_tests/vector_traversal_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/vector_traversal_tests.rs
@@ -13,8 +13,7 @@ use crate::{
             out::{out::OutAdapter, out_e::OutEdgesAdapter},
             source::{
                 add_e::AddEAdapter, add_n::AddNAdapter, e_from_type::EFromTypeAdapter,
-                n_from_id::NFromIdAdapter, v_from_id::VFromIdAdapter,
-                v_from_type::VFromTypeAdapter,
+                n_from_id::NFromIdAdapter, v_from_id::VFromIdAdapter, v_from_type::VFromTypeAdapter,
             },
             util::drop::Drop,
             vectors::{
@@ -30,7 +29,8 @@ use crate::{
 
 type Filter = fn(&HVector, &RoTxn) -> bool;
 
-fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
+fn setup_test_db() -> (TempDir, Arc<HelixGraphStorage>) {
+    let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().to_str().unwrap();
     let storage = HelixGraphStorage::new(
         db_path,
@@ -38,13 +38,12 @@ fn setup_test_db(temp_dir: &TempDir) -> Arc<HelixGraphStorage> {
         Default::default(),
     )
     .unwrap();
-    Arc::new(storage)
+    (temp_dir, Arc::new(storage))
 }
 
 #[test]
 fn test_insert_and_fetch_vector() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -72,8 +71,7 @@ fn test_insert_and_fetch_vector() {
 
 #[test]
 fn test_vector_edges_from_and_to_node() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -107,8 +105,7 @@ fn test_vector_edges_from_and_to_node() {
 
 #[test]
 fn test_brute_force_vector_search_orders_by_distance() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -152,8 +149,7 @@ fn test_brute_force_vector_search_orders_by_distance() {
 
 #[test]
 fn test_drop_vector_removes_edges() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -208,8 +204,7 @@ fn test_drop_vector_removes_edges() {
 
 #[test]
 fn test_v_from_type_basic_with_vector_data() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -233,9 +228,7 @@ fn test_v_from_type_basic_with_vector_data() {
     assert_eq!(results[0].id(), vector_id);
 
     // Verify it's a full HVector with data
-    if let crate::helix_engine::traversal_core::traversal_value::TraversalValue::Vector(v) =
-        &results[0]
-    {
+    if let crate::helix_engine::traversal_core::traversal_value::TraversalValue::Vector(v) = &results[0] {
         assert_eq!(v.data.len(), 3);
         assert_eq!(v.data[0], 1.0);
     } else {
@@ -245,8 +238,7 @@ fn test_v_from_type_basic_with_vector_data() {
 
 #[test]
 fn test_v_from_type_without_vector_data() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -281,8 +273,7 @@ fn test_v_from_type_without_vector_data() {
 
 #[test]
 fn test_v_from_type_multiple_same_label() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -322,8 +313,7 @@ fn test_v_from_type_multiple_same_label() {
 
 #[test]
 fn test_v_from_type_multiple_different_labels() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -356,8 +346,7 @@ fn test_v_from_type_multiple_different_labels() {
 
 #[test]
 fn test_v_from_type_nonexistent_label() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -381,8 +370,7 @@ fn test_v_from_type_nonexistent_label() {
 
 #[test]
 fn test_v_from_type_empty_database() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
 
     // Query empty database
     let arena = Bump::new();
@@ -397,11 +385,10 @@ fn test_v_from_type_empty_database() {
 
 #[test]
 fn test_v_from_type_with_properties() {
-    use crate::protocol::value::Value;
     use std::collections::HashMap;
+    use crate::protocol::value::Value;
 
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -411,20 +398,15 @@ fn test_v_from_type_with_properties() {
     properties.insert("count".to_string(), Value::I64(42));
     properties.insert("score".to_string(), Value::F64(3.14));
     properties.insert("active".to_string(), Value::Boolean(true));
-    properties.insert(
-        "tags".to_string(),
-        Value::Array(vec![
-            Value::String("tag1".to_string()),
-            Value::String("tag2".to_string()),
-        ]),
-    );
+    properties.insert("tags".to_string(), Value::Array(vec![
+        Value::String("tag1".to_string()),
+        Value::String("tag2".to_string()),
+    ]));
 
     // Convert to ImmutablePropertiesMap
     let props_map = ImmutablePropertiesMap::new(
         properties.len(),
-        properties
-            .iter()
-            .map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
+        properties.iter().map(|(k, v)| (arena.alloc_str(k) as &str, v.clone())),
         &arena,
     );
 
@@ -461,8 +443,7 @@ fn test_v_from_type_with_properties() {
 
 #[test]
 fn test_v_from_type_deleted_vectors_filtered() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -513,8 +494,7 @@ fn test_v_from_type_deleted_vectors_filtered() {
 
 #[test]
 fn test_v_from_type_with_edges_and_nodes() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -571,9 +551,9 @@ fn test_v_from_type_with_edges_and_nodes() {
 
 #[test]
 fn test_v_from_type_after_migration() {
-    use crate::helix_engine::storage_core::storage_migration::migrate;
-    use crate::protocol::value::Value;
     use std::collections::HashMap;
+    use crate::protocol::value::Value;
+    use crate::helix_engine::storage_core::storage_migration::migrate;
 
     // Helper to create old-format vector properties (HashMap-based)
     fn create_old_properties(
@@ -593,17 +573,14 @@ fn test_v_from_type_after_migration() {
     }
 
     // Helper to clear metadata (simulates PreMetadata state)
-    fn clear_metadata(
-        storage: &mut crate::helix_engine::storage_core::HelixGraphStorage,
-    ) -> Result<(), crate::helix_engine::types::GraphError> {
+    fn clear_metadata(storage: &mut crate::helix_engine::storage_core::HelixGraphStorage) -> Result<(), crate::helix_engine::types::GraphError> {
         let mut txn = storage.graph_env.write_txn()?;
         storage.metadata_db.clear(&mut txn)?;
         txn.commit()?;
         Ok(())
     }
 
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let mut storage_mut = match Arc::try_unwrap(storage) {
         Ok(s) => s,
         Err(_) => panic!("Failed to unwrap Arc - there are multiple references"),
@@ -630,12 +607,7 @@ fn test_v_from_type_after_migration() {
         // Add actual vector data with proper key format
         let vector_data1: Vec<f64> = vec![1.0, 2.0, 3.0];
         let bytes1: Vec<u8> = vector_data1.iter().flat_map(|f| f.to_be_bytes()).collect();
-        let key1 = [
-            b"v:".as_slice(),
-            &1u128.to_be_bytes(),
-            &0usize.to_be_bytes(),
-        ]
-        .concat();
+        let key1 = [b"v:".as_slice(), &1u128.to_be_bytes(), &0usize.to_be_bytes()].concat();
         storage_mut
             .vectors
             .vectors_db
@@ -656,12 +628,7 @@ fn test_v_from_type_after_migration() {
         // Add actual vector data with proper key format
         let vector_data2: Vec<f64> = vec![4.0, 5.0, 6.0];
         let bytes2: Vec<u8> = vector_data2.iter().flat_map(|f| f.to_be_bytes()).collect();
-        let key2 = [
-            b"v:".as_slice(),
-            &2u128.to_be_bytes(),
-            &0usize.to_be_bytes(),
-        ]
-        .concat();
+        let key2 = [b"v:".as_slice(), &2u128.to_be_bytes(), &0usize.to_be_bytes()].concat();
         storage_mut
             .vectors
             .vectors_db
@@ -681,12 +648,7 @@ fn test_v_from_type_after_migration() {
         // Add actual vector data with proper key format
         let vector_data3: Vec<f64> = vec![7.0, 8.0, 9.0];
         let bytes3: Vec<u8> = vector_data3.iter().flat_map(|f| f.to_be_bytes()).collect();
-        let key3 = [
-            b"v:".as_slice(),
-            &3u128.to_be_bytes(),
-            &0usize.to_be_bytes(),
-        ]
-        .concat();
+        let key3 = [b"v:".as_slice(), &3u128.to_be_bytes(), &0usize.to_be_bytes()].concat();
         storage_mut
             .vectors
             .vectors_db
@@ -711,11 +673,7 @@ fn test_v_from_type_after_migration() {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
 
-    assert_eq!(
-        results_with_data.len(),
-        2,
-        "Should find 2 vectors with test_migration label"
-    );
+    assert_eq!(results_with_data.len(), 2, "Should find 2 vectors with test_migration label");
 
     // Verify we got the right vectors
     let ids: Vec<u128> = results_with_data.iter().map(|v| v.id()).collect();
@@ -723,9 +681,7 @@ fn test_v_from_type_after_migration() {
     assert!(ids.contains(&2u128), "Should contain vector 2");
 
     // Verify vector data is accessible
-    if let crate::helix_engine::traversal_core::traversal_value::TraversalValue::Vector(v) =
-        &results_with_data[0]
-    {
+    if let crate::helix_engine::traversal_core::traversal_value::TraversalValue::Vector(v) = &results_with_data[0] {
         assert_eq!(v.data.len(), 3, "Vector should have 3 dimensions");
     } else {
         panic!("Expected TraversalValue::Vector");
@@ -765,11 +721,7 @@ fn test_v_from_type_after_migration() {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
 
-    assert_eq!(
-        other_results.len(),
-        1,
-        "Should find 1 vector with other_label"
-    );
+    assert_eq!(other_results.len(), 1, "Should find 1 vector with other_label");
     assert_eq!(other_results[0].id(), 3u128);
 
     // Query for non-existent label after migration
@@ -779,10 +731,7 @@ fn test_v_from_type_after_migration() {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
 
-    assert!(
-        empty_results.is_empty(),
-        "Should find no vectors with nonexistent label"
-    );
+    assert!(empty_results.is_empty(), "Should find no vectors with nonexistent label");
 }
 
 // ============================================================================
@@ -791,8 +740,7 @@ fn test_v_from_type_after_migration() {
 
 #[test]
 fn test_v_from_id_with_nonexistent_id_with_data() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let txn = storage.graph_env.read_txn().unwrap();
 
@@ -814,8 +762,7 @@ fn test_v_from_id_with_nonexistent_id_with_data() {
 
 #[test]
 fn test_v_from_id_with_nonexistent_id_without_data() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let txn = storage.graph_env.read_txn().unwrap();
 
@@ -837,8 +784,7 @@ fn test_v_from_id_with_nonexistent_id_without_data() {
 
 #[test]
 fn test_v_from_id_with_deleted_vector() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -886,8 +832,7 @@ fn test_v_from_id_with_deleted_vector() {
 
 #[test]
 fn test_v_from_id_with_zero_id() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let txn = storage.graph_env.read_txn().unwrap();
 
@@ -906,8 +851,7 @@ fn test_v_from_id_with_zero_id() {
 
 #[test]
 fn test_v_from_id_with_max_id() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let txn = storage.graph_env.read_txn().unwrap();
 
@@ -926,8 +870,7 @@ fn test_v_from_id_with_max_id() {
 
 #[test]
 fn test_search_v_filters_by_type() {
-    let temp_dir = TempDir::new().unwrap();
-    let storage = setup_test_db(&temp_dir);
+    let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
@@ -968,29 +911,16 @@ fn test_search_v_filters_by_type() {
         .unwrap();
 
     // Should only return the 2 vectors with type "type_b"
-    assert_eq!(
-        results.len(),
-        2,
-        "search_v should only return vectors of the specified type"
-    );
+    assert_eq!(results.len(), 2, "search_v should only return vectors of the specified type");
 
     let result_ids: Vec<u128> = results.iter().map(|v| v.id()).collect();
     assert!(result_ids.contains(&v1_b.id()), "Should contain v1_b");
     assert!(result_ids.contains(&v2_b.id()), "Should contain v2_b");
 
     // Verify type_a and type_c vectors are NOT in the results
-    assert!(
-        !result_ids.contains(&v1_a.id()),
-        "Should NOT contain v1_a (type_a)"
-    );
-    assert!(
-        !result_ids.contains(&v2_a.id()),
-        "Should NOT contain v2_a (type_a)"
-    );
-    assert!(
-        !result_ids.contains(&v1_c.id()),
-        "Should NOT contain v1_c (type_c)"
-    );
+    assert!(!result_ids.contains(&v1_a.id()), "Should NOT contain v1_a (type_a)");
+    assert!(!result_ids.contains(&v2_a.id()), "Should NOT contain v2_a (type_a)");
+    assert!(!result_ids.contains(&v1_c.id()), "Should NOT contain v1_c (type_c)");
 
     // Also verify by searching for type_a - should only get type_a vectors
     let arena = Bump::new();
@@ -999,11 +929,7 @@ fn test_search_v_filters_by_type() {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
 
-    assert_eq!(
-        results_a.len(),
-        2,
-        "search_v for type_a should return 2 vectors"
-    );
+    assert_eq!(results_a.len(), 2, "search_v for type_a should return 2 vectors");
     let result_a_ids: Vec<u128> = results_a.iter().map(|v| v.id()).collect();
     assert!(result_a_ids.contains(&v1_a.id()));
     assert!(result_a_ids.contains(&v2_a.id()));
@@ -1015,10 +941,6 @@ fn test_search_v_filters_by_type() {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
 
-    assert_eq!(
-        results_c.len(),
-        1,
-        "search_v for type_c should return 1 vector"
-    );
+    assert_eq!(results_c.len(), 1, "search_v for type_c should return 1 vector");
     assert_eq!(results_c[0].id(), v1_c.id());
 }


### PR DESCRIPTION
Reverts HelixDB/helix-db#785

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR reverts PR #785, which attempted to fix a perceived `TempDir` lifetime bug by changing the test setup pattern. However, both patterns are actually safe:

**Original Pattern (restored by this revert):**
- `setup_test_db()` returns `(TempDir, Arc<Storage>)` tuple
- Tests use: `let (_temp_dir, storage) = setup_test_db();`
- The `_temp_dir` binding maintains the `TempDir` lifetime for the entire test scope

**PR #785 Pattern (being reverted):**
- `setup_test_db(&TempDir)` takes `&TempDir` parameter
- Tests use: `let temp_dir = TempDir::new(); let storage = setup_test_db(&temp_dir);`
- Explicit `TempDir` management in test scope

Both approaches correctly maintain the `TempDir` RAII guard's lifetime, preventing premature directory cleanup. The tuple-return pattern is simpler and more ergonomic.

**Critical Issue: Disabled Concurrency Tests**
- All three CI workflows now skip concurrency tests with `--skip concurrency_tests`
- This removes validation of MVCC behavior, thread safety, and race conditions
- Concurrency tests are essential for a database that will be used in multi-threaded environments
- The workflow changes undermine the value of having these tests in the codebase

**Recommendation:**
The test code changes are safe, but disabling concurrency tests in CI is problematic. If these tests are flaky or have issues, the root cause should be investigated and fixed rather than skipping them entirely.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/db_tests.yml | Re-disables concurrency tests in CI by adding `--skip concurrency_tests` flag, which defeats the purpose of testing concurrent behavior |
| .github/workflows/dev_instance_tests.yml | Re-disables concurrency tests in dev instance CI, removing important multi-threading validation |
| .github/workflows/production_db_tests.yml | Re-disables concurrency tests in production CI, which is especially problematic for production builds |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test as Test Function
    participant SetupFn as setup_test_db()
    participant TempDir as TempDir (RAII Guard)
    participant Storage as HelixGraphStorage
    participant FS as File System

    Note over Test,FS: Pattern in PR #785 (being reverted)
    Test->>Test: let temp_dir = TempDir::new()
    Test->>FS: Create temp directory
    Test->>SetupFn: setup_test_db(&temp_dir)
    SetupFn->>Storage: Create HelixGraphStorage(path)
    Storage->>FS: Open database files
    SetupFn-->>Test: Return Arc<Storage>
    Test->>Storage: Use storage in test
    Storage->>FS: File operations succeed
    Note over Test: temp_dir still in scope
    Test->>Test: Test completes
    Test->>TempDir: Drop temp_dir
    TempDir->>FS: Cleanup directory
    
    Note over Test,FS: Pattern After This Revert (tuple-return)
    Test->>SetupFn: setup_test_db()
    SetupFn->>TempDir: Create TempDir::new()
    SetupFn->>FS: Create temp directory
    SetupFn->>Storage: Create HelixGraphStorage(path)
    Storage->>FS: Open database files
    SetupFn-->>Test: Return (TempDir, Arc<Storage>)
    Test->>Test: let (_temp_dir, storage) = result
    Note over Test: _temp_dir binding keeps TempDir alive
    Test->>Storage: Use storage in test
    Storage->>FS: File operations succeed
    Test->>Test: Test completes
    Test->>TempDir: Drop _temp_dir
    TempDir->>FS: Cleanup directory

    Note over Test,FS: Both patterns are safe - TempDir outlives Storage
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->