### PR TITLE
feat(cli): add branch command for local instance database management

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -197,6 +197,7 @@ helix-cli/
 - `helix add` - Add dependencies to project
 - `helix auth` - Authentication management (login/logout/create-key)
 - `helix build` - Build queries without deploying
+- `helix branch` - Branch a local instance database
 - `helix check` - Validate schema and query syntax
 - `helix compile` - Compile queries to Rust code
 - `helix delete` - Remove instance and data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,6 +1394,7 @@ dependencies = [
  "dotenvy",
  "eyre",
  "flume",
+ "fs2",
  "futures-util",
  "heed3",
  "helix-db",

--- a/helix-cli/Cargo.toml
+++ b/helix-cli/Cargo.toml
@@ -31,6 +31,7 @@ indicatif = "0.18.3"
 webbrowser = "1.0"
 heed3 = "0.22.0"
 open = "5.3"
+fs2 = "0.4.3"
 
 [dev-dependencies]
 tempfile = "3.23.0"

--- a/helix-cli/README.md
+++ b/helix-cli/README.md
@@ -15,6 +15,12 @@ push
     - (--force/--f)
 pull
     - (<cluster_id|alias>)
+branch
+    - (<instance>)
+    - (--output/--o)
+    - (--deploy)
+    - (--name)
+    - (--port)
 init
     - (--template/--t): template to use e.g. ts, py, fli.io, docker etc.
     - (--alias/--a): name to call cluster

--- a/helix-cli/README.md
+++ b/helix-cli/README.md
@@ -18,7 +18,6 @@ pull
 branch
     - (<instance>)
     - (--output/--o)
-    - (--deploy)
     - (--name)
     - (--port)
 init

--- a/helix-cli/src/commands/add.rs
+++ b/helix-cli/src/commands/add.rs
@@ -239,6 +239,7 @@ async fn run_add_inner(
             let local_config = LocalInstanceConfig {
                 port: None, // Let the system assign a port
                 build_mode: BuildMode::Debug,
+                data_dir: None,
                 db_config: DbConfig::default(),
             };
 

--- a/helix-cli/src/commands/branch.rs
+++ b/helix-cli/src/commands/branch.rs
@@ -1,4 +1,4 @@
-use crate::commands::build;
+use crate::commands::{backup::backup_instance_to_dir, build};
 use crate::config::{InstanceInfo, LocalInstanceConfig};
 use crate::docker::DockerManager;
 use crate::metrics_sender::MetricsSender;
@@ -6,17 +6,13 @@ use crate::project::ProjectContext;
 use crate::prompts;
 use crate::utils::{print_confirm, print_status, print_success, print_warning};
 use eyre::{Result, eyre};
-use heed3::{CompactionOption, EnvFlags, EnvOpenOptions};
 use std::fs;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 
-const TEN_GB: u64 = 10 * 1024 * 1024 * 1024;
-
 pub async fn run(
     instance: String,
     output: Option<PathBuf>,
-    deploy: bool,
     name: Option<String>,
     port: Option<u16>,
     metrics_sender: &MetricsSender,
@@ -31,80 +27,31 @@ pub async fn run(
     };
 
     let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S").to_string();
-    let branch_name = if deploy {
-        name.unwrap_or_else(|| format!("{instance}-branch-{timestamp}"))
-    } else {
-        if name.is_some() {
-            print_warning("--name is ignored unless --deploy is set");
-        }
-        String::new()
-    };
-
-    let output_dir = resolve_output_dir(&project, output, deploy, &branch_name, &timestamp);
+    let branch_name = name.unwrap_or_else(|| format!("{instance}-branch-{timestamp}"));
+    ensure_branch_name_available(&project, &branch_name)?;
+    let output_dir = resolve_output_dir(&project, output, &branch_name);
     let output_user_dir = output_dir.join("user");
 
     print_status(
         "BRANCH",
         &format!(
-            "Branching instance '{instance}' to {}",
+            "Creating new local instance from '{instance}' at {}",
             output_dir.display()
         ),
     );
 
-    let env_path = project.instance_user_dir(&instance)?;
-    let data_file = project.instance_data_file(&instance)?;
-    let env_path = Path::new(&env_path);
-
-    if !env_path.exists() {
-        return Err(eyre!(
-            "Instance LMDB environment not found at {:?}",
-            env_path
-        ));
-    }
-
-    if !data_file.exists() {
-        return Err(eyre!("Instance data file not found at {:?}", data_file));
-    }
-
     prepare_output_user_dir(&output_user_dir)?;
-
-    let total_size = fs::metadata(&data_file)?.len();
-    if total_size > TEN_GB {
-        let size_gb = (total_size as f64) / (1024.0 * 1024.0 * 1024.0);
-        print_warning(&format!(
-            "Branch size is {:.2} GB. Taking atomic snapshot... this may take time depending on DB size",
-            size_gb
-        ));
-        let confirmed = print_confirm("Do you want to continue?")?;
-        if !confirmed {
-            print_status("CANCEL", "Branch aborted by user");
-            return Ok(());
-        }
-    }
-
-    let env = unsafe {
-        EnvOpenOptions::new()
-            .flags(EnvFlags::READ_ONLY)
-            .max_dbs(200)
-            .max_readers(200)
-            .open(env_path)?
-    };
-
-    env.copy_to_path(output_user_dir.join("data.mdb"), CompactionOption::Disabled)?;
-
-    print_success(&format!(
-        "Branch for '{instance}' created at {}",
-        output_dir.display()
-    ));
-
-    if !deploy {
+    let backup_completed = backup_instance_to_dir(&project, &instance, &output_user_dir)?;
+    if !backup_completed {
         return Ok(());
     }
 
-    let port = match port {
-        Some(port) => port,
-        None => select_available_port()?,
-    };
+    print_success(&format!(
+        "New local instance data created at {}",
+        output_dir.display()
+    ));
+
+    let port = resolve_branch_port(port)?;
 
     let branch_config = LocalInstanceConfig {
         port: Some(port),
@@ -126,7 +73,9 @@ pub async fn run(
     let docker = DockerManager::new(&project);
     docker.start_instance(&branch_name)?;
 
-    print_success(&format!("Instance '{branch_name}' is now running"));
+    print_success(&format!(
+        "Branched local instance '{branch_name}' is now running"
+    ));
     println!("  Local URL: http://localhost:{port}");
     let project_name = &project.config.project.name;
     println!("  Container: helix_{project_name}_{branch_name}");
@@ -138,9 +87,7 @@ pub async fn run(
 pub(crate) fn resolve_output_dir(
     project: &ProjectContext,
     output: Option<PathBuf>,
-    deploy: bool,
     branch_name: &str,
-    timestamp: &str,
 ) -> PathBuf {
     match output {
         Some(path) => {
@@ -150,16 +97,7 @@ pub(crate) fn resolve_output_dir(
                 project.root.join(path)
             }
         }
-        None => {
-            if deploy {
-                project.helix_dir.join(".volumes").join(branch_name)
-            } else {
-                project
-                    .helix_dir
-                    .join(".branches")
-                    .join(format!("branch-{timestamp}"))
-            }
-        }
+        None => project.helix_dir.join(".volumes").join(branch_name),
     }
 }
 
@@ -218,4 +156,130 @@ fn select_available_port() -> Result<u16> {
     let listener = TcpListener::bind("127.0.0.1:0")?;
     let port = listener.local_addr()?.port();
     Ok(port)
+}
+
+fn resolve_branch_port(port: Option<u16>) -> Result<u16> {
+    match port {
+        Some(port) => {
+            ensure_port_available(port)?;
+            Ok(port)
+        }
+        None => select_available_port(),
+    }
+}
+
+fn ensure_port_available(port: u16) -> Result<()> {
+    TcpListener::bind(("127.0.0.1", port)).map_err(|err| {
+        eyre!(
+            "Port {port} is not available for the branched instance: {err}"
+        )
+    })?;
+    Ok(())
+}
+
+fn ensure_branch_name_available(project: &ProjectContext, branch_name: &str) -> Result<()> {
+    if project.config.local.contains_key(branch_name)
+        || project.config.cloud.contains_key(branch_name)
+    {
+        return Err(eyre!("Instance '{branch_name}' already exists"));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_branch_name_available, ensure_port_available};
+    use crate::config::{
+        BuildMode, CloudConfig, CloudInstanceConfig, DbConfig, HelixConfig, LocalInstanceConfig,
+    };
+    use crate::project::ProjectContext;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::net::TcpListener;
+    use tempfile::TempDir;
+
+    fn setup_test_project() -> (TempDir, ProjectContext) {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let project_path = temp_dir.path().to_path_buf();
+
+        let config = HelixConfig::default_config("test-project");
+        let config_path = project_path.join("helix.toml");
+        config
+            .save_to_file(&config_path)
+            .expect("Failed to save config");
+
+        fs::create_dir_all(project_path.join(".helix")).expect("Failed to create .helix");
+
+        let context = ProjectContext::find_and_load(Some(&project_path))
+            .expect("Failed to load project context");
+
+        (temp_dir, context)
+    }
+
+    #[test]
+    fn test_ensure_port_available_rejects_bound_port() {
+        let listener =
+            TcpListener::bind("127.0.0.1:0").expect("Failed to bind to random port");
+        let port = listener
+            .local_addr()
+            .expect("Failed to read local addr")
+            .port();
+
+        let result = ensure_port_available(port);
+        assert!(result.is_err(), "Expected port to be unavailable");
+    }
+
+    #[test]
+    fn test_ensure_port_available_allows_free_port() {
+        let listener =
+            TcpListener::bind("127.0.0.1:0").expect("Failed to bind to random port");
+        let port = listener
+            .local_addr()
+            .expect("Failed to read local addr")
+            .port();
+        drop(listener);
+
+        let result = ensure_port_available(port);
+        assert!(result.is_ok(), "Expected port to be available");
+    }
+
+    #[test]
+    fn test_ensure_branch_name_available_rejects_existing() {
+        let (_temp_dir, mut project) = setup_test_project();
+
+        project.config.local.insert(
+            "existing-local".to_string(),
+            LocalInstanceConfig {
+                port: Some(7777),
+                build_mode: BuildMode::Debug,
+                data_dir: None,
+                db_config: DbConfig::default(),
+            },
+        );
+
+        project.config.cloud.insert(
+            "existing-cloud".to_string(),
+            CloudConfig::Helix(CloudInstanceConfig {
+                cluster_id: "cluster".to_string(),
+                region: None,
+                build_mode: BuildMode::Debug,
+                env_vars: HashMap::new(),
+                db_config: DbConfig::default(),
+            }),
+        );
+
+        let local_result = ensure_branch_name_available(&project, "existing-local");
+        assert!(local_result.is_err(), "Expected local name to be rejected");
+
+        let cloud_result = ensure_branch_name_available(&project, "existing-cloud");
+        assert!(cloud_result.is_err(), "Expected cloud name to be rejected");
+    }
+
+    #[test]
+    fn test_ensure_branch_name_available_allows_unique() {
+        let (_temp_dir, project) = setup_test_project();
+        let result = ensure_branch_name_available(&project, "unique-branch");
+        assert!(result.is_ok(), "Expected branch name to be available");
+    }
 }

--- a/helix-cli/src/commands/branch.rs
+++ b/helix-cli/src/commands/branch.rs
@@ -1,0 +1,221 @@
+use crate::commands::build;
+use crate::config::{InstanceInfo, LocalInstanceConfig};
+use crate::docker::DockerManager;
+use crate::metrics_sender::MetricsSender;
+use crate::project::ProjectContext;
+use crate::prompts;
+use crate::utils::{print_confirm, print_status, print_success, print_warning};
+use eyre::{Result, eyre};
+use heed3::{CompactionOption, EnvFlags, EnvOpenOptions};
+use std::fs;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+
+const TEN_GB: u64 = 10 * 1024 * 1024 * 1024;
+
+pub async fn run(
+    instance: String,
+    output: Option<PathBuf>,
+    deploy: bool,
+    name: Option<String>,
+    port: Option<u16>,
+    metrics_sender: &MetricsSender,
+) -> Result<()> {
+    let mut project = ProjectContext::find_and_load(None)?;
+    let instance_config = project.config.get_instance(&instance)?;
+    let source_config = match instance_config {
+        InstanceInfo::Local(config) => config,
+        _ => {
+            return Err(eyre!("Branch is only supported for local instances"));
+        }
+    };
+
+    let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S").to_string();
+    let branch_name = if deploy {
+        name.unwrap_or_else(|| format!("{instance}-branch-{timestamp}"))
+    } else {
+        if name.is_some() {
+            print_warning("--name is ignored unless --deploy is set");
+        }
+        String::new()
+    };
+
+    let output_dir = resolve_output_dir(&project, output, deploy, &branch_name, &timestamp);
+    let output_user_dir = output_dir.join("user");
+
+    print_status(
+        "BRANCH",
+        &format!(
+            "Branching instance '{instance}' to {}",
+            output_dir.display()
+        ),
+    );
+
+    let env_path = project.instance_user_dir(&instance)?;
+    let data_file = project.instance_data_file(&instance)?;
+    let env_path = Path::new(&env_path);
+
+    if !env_path.exists() {
+        return Err(eyre!(
+            "Instance LMDB environment not found at {:?}",
+            env_path
+        ));
+    }
+
+    if !data_file.exists() {
+        return Err(eyre!("Instance data file not found at {:?}", data_file));
+    }
+
+    prepare_output_user_dir(&output_user_dir)?;
+
+    let total_size = fs::metadata(&data_file)?.len();
+    if total_size > TEN_GB {
+        let size_gb = (total_size as f64) / (1024.0 * 1024.0 * 1024.0);
+        print_warning(&format!(
+            "Branch size is {:.2} GB. Taking atomic snapshot... this may take time depending on DB size",
+            size_gb
+        ));
+        let confirmed = print_confirm("Do you want to continue?")?;
+        if !confirmed {
+            print_status("CANCEL", "Branch aborted by user");
+            return Ok(());
+        }
+    }
+
+    let env = unsafe {
+        EnvOpenOptions::new()
+            .flags(EnvFlags::READ_ONLY)
+            .max_dbs(200)
+            .max_readers(200)
+            .open(env_path)?
+    };
+
+    env.copy_to_path(output_user_dir.join("data.mdb"), CompactionOption::Disabled)?;
+
+    print_success(&format!(
+        "Branch for '{instance}' created at {}",
+        output_dir.display()
+    ));
+
+    if !deploy {
+        return Ok(());
+    }
+
+    let port = match port {
+        Some(port) => port,
+        None => select_available_port()?,
+    };
+
+    let branch_config = LocalInstanceConfig {
+        port: Some(port),
+        build_mode: source_config.build_mode,
+        data_dir: Some(output_dir.clone()),
+        db_config: source_config.db_config.clone(),
+    };
+
+    persist_branch_config(&mut project, &branch_name, branch_config)?;
+
+    print_status(
+        "DEPLOY",
+        &format!("Deploying branched instance '{branch_name}'"),
+    );
+
+    DockerManager::check_runtime_available(project.config.project.container_runtime)?;
+    build::run(Some(branch_name.clone()), metrics_sender).await?;
+
+    let docker = DockerManager::new(&project);
+    docker.start_instance(&branch_name)?;
+
+    print_success(&format!("Instance '{branch_name}' is now running"));
+    println!("  Local URL: http://localhost:{port}");
+    let project_name = &project.config.project.name;
+    println!("  Container: helix_{project_name}_{branch_name}");
+    println!("  Data volume: {}", output_dir.display());
+
+    Ok(())
+}
+
+pub(crate) fn resolve_output_dir(
+    project: &ProjectContext,
+    output: Option<PathBuf>,
+    deploy: bool,
+    branch_name: &str,
+    timestamp: &str,
+) -> PathBuf {
+    match output {
+        Some(path) => {
+            if path.is_absolute() {
+                path
+            } else {
+                project.root.join(path)
+            }
+        }
+        None => {
+            if deploy {
+                project.helix_dir.join(".volumes").join(branch_name)
+            } else {
+                project
+                    .helix_dir
+                    .join(".branches")
+                    .join(format!("branch-{timestamp}"))
+            }
+        }
+    }
+}
+
+pub(crate) fn prepare_output_user_dir(output_user_dir: &Path) -> Result<()> {
+    if output_user_dir.exists() {
+        let data_path = output_user_dir.join("data.mdb");
+        let has_entries = data_path.exists() || fs::read_dir(output_user_dir)?.next().is_some();
+        if has_entries {
+            if prompts::is_interactive() {
+                print_warning(&format!(
+                    "Output directory already exists at {}",
+                    output_user_dir.display()
+                ));
+                let confirmed = print_confirm("Overwrite existing branch output directory?")?;
+                if !confirmed {
+                    return Err(eyre!(
+                        "Output directory already exists at {}",
+                        output_user_dir.display()
+                    ));
+                }
+                fs::remove_dir_all(output_user_dir)?;
+            } else {
+                return Err(eyre!(
+                    "Output directory already exists at {}",
+                    output_user_dir.display()
+                ));
+            }
+        }
+    }
+
+    fs::create_dir_all(output_user_dir)?;
+    Ok(())
+}
+
+pub(crate) fn persist_branch_config(
+    project: &mut ProjectContext,
+    branch_name: &str,
+    branch_config: LocalInstanceConfig,
+) -> Result<()> {
+    if project.config.local.contains_key(branch_name)
+        || project.config.cloud.contains_key(branch_name)
+    {
+        return Err(eyre!("Instance '{branch_name}' already exists"));
+    }
+
+    project
+        .config
+        .local
+        .insert(branch_name.to_string(), branch_config);
+    let config_path = project.root.join("helix.toml");
+    project.config.save_to_file(&config_path)?;
+    Ok(())
+}
+
+fn select_available_port() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    Ok(port)
+}

--- a/helix-cli/src/commands/check.rs
+++ b/helix-cli/src/commands/check.rs
@@ -50,10 +50,10 @@ async fn check_instance(
     print_success("Syntax validation passed");
 
     // Step 2: Ensure helix repo is cached (reuse from build.rs)
-    build::ensure_helix_repo_cached().await?;
+    build::ensure_helix_repo_cached()?;
 
     // Step 3: Prepare instance workspace (reuse from build.rs)
-    build::prepare_instance_workspace(project, instance_name).await?;
+    build::prepare_instance_workspace(project, instance_name)?;
 
     // Step 4: Compile project - generate queries.rs (reuse from build.rs)
     let metrics_data = build::compile_project(project, instance_name).await?;
@@ -115,7 +115,12 @@ async fn check_all_instances(
 ) -> Result<()> {
     print_status("CHECK", "Checking all instances");
 
-    let instances: Vec<String> = project.config.list_instances().into_iter().map(String::from).collect();
+    let instances: Vec<String> = project
+        .config
+        .list_instances()
+        .into_iter()
+        .map(String::from)
+        .collect();
 
     if instances.is_empty() {
         return Err(eyre::eyre!(
@@ -193,7 +198,8 @@ fn handle_cargo_check_failure(
     print_warning("You can report this issue to help improve Helix.");
     println!();
 
-    let should_create = print_confirm("Would you like to create a GitHub issue with diagnostic information?")?;
+    let should_create =
+        print_confirm("Would you like to create a GitHub issue with diagnostic information?")?;
 
     if !should_create {
         return Ok(());

--- a/helix-cli/src/commands/delete.rs
+++ b/helix-cli/src/commands/delete.rs
@@ -62,7 +62,10 @@ pub async fn run(instance_name: String) -> Result<()> {
     }
 
     // Remove instance volumes (permanent data loss)
-    let volume = project.instance_volume(&instance_name);
+    let volume = match &instance_config {
+        InstanceInfo::Local(_) => project.instance_data_dir(&instance_name)?,
+        _ => project.instance_volume(&instance_name),
+    };
     if volume.exists() {
         std::fs::remove_dir_all(&volume)?;
         print_status("DELETE", "Removed persistent volumes");

--- a/helix-cli/src/commands/migrate.rs
+++ b/helix-cli/src/commands/migrate.rs
@@ -431,6 +431,7 @@ fn create_v2_config(ctx: &MigrationContext) -> Result<()> {
     let local_config = LocalInstanceConfig {
         port: Some(ctx.port),
         build_mode: BuildMode::Debug,
+        data_dir: None,
         db_config,
     };
 

--- a/helix-cli/src/commands/mod.rs
+++ b/helix-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod add;
 pub mod auth;
 pub mod backup;
+pub mod branch;
 pub mod build;
 pub mod check;
 pub mod compile;

--- a/helix-cli/src/commands/push.rs
+++ b/helix-cli/src/commands/push.rs
@@ -149,9 +149,10 @@ async fn push_local_instance(
     println!("  Local URL: http://localhost:{port}");
     let project_name = &project.config.project.name;
     println!("  Container: helix_{project_name}_{instance_name}");
+    let data_dir = project.instance_data_dir(instance_name)?;
     println!(
         "  Data volume: {}",
-        project.instance_volume(instance_name).display()
+        data_dir.display()
     );
 
     Ok(metrics_data)

--- a/helix-cli/src/commands/start.rs
+++ b/helix-cli/src/commands/start.rs
@@ -72,9 +72,10 @@ async fn start_local_instance(project: &ProjectContext, instance_name: &str) -> 
     println!("  Local URL: http://localhost:{port}");
     let project_name = &project.config.project.name;
     println!("  Container: helix_{project_name}_{instance_name}");
+    let data_dir = project.instance_data_dir(instance_name)?;
     println!(
         "  Data volume: {}",
-        project.instance_volume(instance_name).display()
+        data_dir.display()
     );
 
     Ok(())

--- a/helix-cli/src/docker.rs
+++ b/helix-cli/src/docker.rs
@@ -607,7 +607,6 @@ networks:
             platform = instance_config
                 .docker_build_target()
                 .map_or("".to_string(), |p| format!("platforms:\n        - {p}")),
-            volume_source = volume_source,
         );
 
         Ok(compose)

--- a/helix-cli/src/docker.rs
+++ b/helix-cli/src/docker.rs
@@ -150,6 +150,16 @@ impl<'a> DockerManager<'a> {
         format!("{project_name}_net")
     }
 
+    /// Format a Docker Compose volume spec, keeping Windows absolute paths safe.
+    fn compose_volume_spec(&self, volume_source: &str) -> String {
+        if cfg!(windows) && volume_source.contains(':') {
+            let normalized = volume_source.replace('\\', "/");
+            format!("\"{}:{}\"", normalized, HELIX_DATA_DIR)
+        } else {
+            format!("{}:{}", volume_source, HELIX_DATA_DIR)
+        }
+    }
+
     // === CENTRALIZED DOCKER/PODMAN COMMAND EXECUTION ===
 
     /// Run a docker/podman command with consistent error handling
@@ -544,6 +554,19 @@ CMD ["helix-container"]
         instance_config: InstanceInfo<'_>,
     ) -> Result<String> {
         let port = instance_config.port().unwrap_or(6969);
+        let default_volume = self.project.instance_volume(instance_name);
+        let volume_source = if instance_config.is_local() {
+            let data_dir = self.project.instance_data_dir(instance_name)?;
+            if data_dir == default_volume {
+                format!("../.volumes/{instance_name}")
+            } else {
+                data_dir.display().to_string()
+            }
+        } else {
+            format!("../.volumes/{instance_name}")
+        };
+
+        let volume_spec = self.compose_volume_spec(&volume_source);
 
         // Use centralized naming methods
         let service_name = Self::service_name();
@@ -570,7 +593,7 @@ services:
     ports:
       - "{port}:{port}"
     volumes:
-      - ../.volumes/{instance_name}:/data
+      - {volume_spec}
     environment:
 {env_section}
     restart: unless-stopped
@@ -584,6 +607,7 @@ networks:
             platform = instance_config
                 .docker_build_target()
                 .map_or("".to_string(), |p| format!("platforms:\n        - {p}")),
+            volume_source = volume_source,
         );
 
         Ok(compose)

--- a/helix-cli/src/main.rs
+++ b/helix-cli/src/main.rs
@@ -190,6 +190,28 @@ enum Commands {
         output: Option<PathBuf>,
     },
 
+    /// Branch a local instance database to a new directory
+    Branch {
+        /// Instance name to branch
+        instance: String,
+
+        /// Output directory for the branch
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Deploy the branched instance locally
+        #[arg(long)]
+        deploy: bool,
+
+        /// Name of the branched instance when deploying
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Port for the branched instance when deploying
+        #[arg(long)]
+        port: Option<u16>,
+    },
+
     /// Send feedback to the Helix team
     Feedback {
         /// Feedback message (opens interactive prompt if not provided)
@@ -229,7 +251,9 @@ async fn main() -> Result<()> {
         Commands::Build { instance } => commands::build::run(instance, &metrics_sender)
             .await
             .map(|_| ()),
-        Commands::Push { instance, dev } => commands::push::run(instance, dev, &metrics_sender).await,
+        Commands::Push { instance, dev } => {
+            commands::push::run(instance, dev, &metrics_sender).await
+        }
         Commands::Pull { instance } => commands::pull::run(instance).await,
         Commands::Start { instance } => commands::start::run(instance).await,
         Commands::Stop { instance } => commands::stop::run(instance).await,
@@ -251,6 +275,13 @@ async fn main() -> Result<()> {
             commands::migrate::run(path, queries_dir, instance_name, port, dry_run, no_backup).await
         }
         Commands::Backup { instance, output } => commands::backup::run(output, instance).await,
+        Commands::Branch {
+            instance,
+            output,
+            deploy,
+            name,
+            port,
+        } => commands::branch::run(instance, output, deploy, name, port, &metrics_sender).await,
         Commands::Feedback { message } => commands::feedback::run(message).await,
     };
 

--- a/helix-cli/src/main.rs
+++ b/helix-cli/src/main.rs
@@ -190,7 +190,7 @@ enum Commands {
         output: Option<PathBuf>,
     },
 
-    /// Branch a local instance database to a new directory
+    /// Branch a local instance database into a new local instance
     Branch {
         /// Instance name to branch
         instance: String,
@@ -199,15 +199,11 @@ enum Commands {
         #[arg(short, long)]
         output: Option<PathBuf>,
 
-        /// Deploy the branched instance locally
-        #[arg(long)]
-        deploy: bool,
-
-        /// Name of the branched instance when deploying
+        /// Name of the branched instance
         #[arg(long)]
         name: Option<String>,
 
-        /// Port for the branched instance when deploying
+        /// Port for the branched instance
         #[arg(long)]
         port: Option<u16>,
     },
@@ -278,10 +274,9 @@ async fn main() -> Result<()> {
         Commands::Branch {
             instance,
             output,
-            deploy,
             name,
             port,
-        } => commands::branch::run(instance, output, deploy, name, port, &metrics_sender).await,
+        } => commands::branch::run(instance, output, name, port, &metrics_sender).await,
         Commands::Feedback { message } => commands::feedback::run(message).await,
     };
 

--- a/helix-cli/src/tests/backup_tests.rs
+++ b/helix-cli/src/tests/backup_tests.rs
@@ -1,0 +1,67 @@
+use crate::commands::backup::backup_instance_to_dir;
+use crate::config::{BuildMode, DbConfig, HelixConfig, LocalInstanceConfig};
+use crate::project::ProjectContext;
+use heed3::EnvOpenOptions;
+use std::fs;
+use tempfile::TempDir;
+
+fn setup_test_project() -> (TempDir, ProjectContext) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let project_path = temp_dir.path().to_path_buf();
+
+    let config = HelixConfig::default_config("test-project");
+    let config_path = project_path.join("helix.toml");
+    config
+        .save_to_file(&config_path)
+        .expect("Failed to save config");
+
+    fs::create_dir_all(project_path.join(".helix")).expect("Failed to create .helix");
+
+    let context =
+        ProjectContext::find_and_load(Some(&project_path)).expect("Failed to load project context");
+
+    (temp_dir, context)
+}
+
+#[test]
+fn test_backup_instance_to_dir_copies_data_file() {
+    let (temp_dir, mut project) = setup_test_project();
+    let instance_name = "primary";
+    let data_dir = project.root.join("data-dir");
+
+    project.config.local.insert(
+        instance_name.to_string(),
+        LocalInstanceConfig {
+            port: Some(7777),
+            build_mode: BuildMode::Debug,
+            data_dir: Some(data_dir.clone()),
+            db_config: DbConfig::default(),
+        },
+    );
+
+    let user_dir = data_dir.join("user");
+    fs::create_dir_all(&user_dir).expect("Failed to create user dir");
+    {
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .max_dbs(1)
+                .open(&user_dir)
+                .expect("Failed to create LMDB env")
+        };
+        drop(env);
+    }
+    assert!(
+        user_dir.join("data.mdb").exists(),
+        "Expected LMDB data.mdb to exist"
+    );
+
+    let output_dir = temp_dir.path().join("backup-output");
+    let completed =
+        backup_instance_to_dir(&project, instance_name, &output_dir).expect("Backup failed");
+
+    assert!(completed, "Expected backup to complete");
+    assert!(
+        output_dir.join("data.mdb").exists(),
+        "Expected backup data.mdb to exist"
+    );
+}

--- a/helix-cli/src/tests/branch_tests.rs
+++ b/helix-cli/src/tests/branch_tests.rs
@@ -1,0 +1,100 @@
+use crate::commands::branch::{persist_branch_config, prepare_output_user_dir, resolve_output_dir};
+use crate::config::{BuildMode, DbConfig, HelixConfig, LocalInstanceConfig};
+use crate::project::ProjectContext;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn setup_test_project() -> (TempDir, ProjectContext) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let project_path = temp_dir.path().to_path_buf();
+
+    let config = HelixConfig::default_config("test-project");
+    let config_path = project_path.join("helix.toml");
+    config
+        .save_to_file(&config_path)
+        .expect("Failed to save config");
+
+    fs::create_dir_all(project_path.join(".helix")).expect("Failed to create .helix");
+
+    let context =
+        ProjectContext::find_and_load(Some(&project_path)).expect("Failed to load project context");
+
+    (temp_dir, context)
+}
+
+#[test]
+fn test_resolve_output_dir_defaults() {
+    let (_temp_dir, project) = setup_test_project();
+    let timestamp = "20240101-000000";
+
+    let deploy_output = resolve_output_dir(&project, None, true, "branch-1", timestamp);
+    assert_eq!(
+        deploy_output,
+        project.helix_dir.join(".volumes").join("branch-1")
+    );
+
+    let branch_output = resolve_output_dir(&project, None, false, "", timestamp);
+    assert_eq!(
+        branch_output,
+        project
+            .helix_dir
+            .join(".branches")
+            .join(format!("branch-{timestamp}"))
+    );
+}
+
+#[test]
+fn test_resolve_output_dir_relative_path() {
+    let (_temp_dir, project) = setup_test_project();
+    let timestamp = "20240101-000000";
+    let output = resolve_output_dir(
+        &project,
+        Some(PathBuf::from("custom-output")),
+        false,
+        "",
+        timestamp,
+    );
+    assert_eq!(output, project.root.join("custom-output"));
+}
+
+#[test]
+fn test_branch_persists_deploy_config() {
+    let (_temp_dir, mut project) = setup_test_project();
+    let branch_name = "branch-1";
+    let output_dir = project.root.join("branch-output");
+
+    let branch_config = LocalInstanceConfig {
+        port: Some(7777),
+        build_mode: BuildMode::Debug,
+        data_dir: Some(output_dir.clone()),
+        db_config: DbConfig::default(),
+    };
+
+    persist_branch_config(&mut project, branch_name, branch_config)
+        .expect("Failed to persist branch config");
+
+    let config_path = project.root.join("helix.toml");
+    let reloaded = HelixConfig::from_file(&config_path).expect("Failed to reload config");
+    let saved = reloaded
+        .local
+        .get(branch_name)
+        .expect("Missing persisted branch config");
+
+    assert_eq!(saved.port, Some(7777));
+    assert_eq!(saved.data_dir.as_ref(), Some(&output_dir));
+}
+
+#[test]
+fn test_prepare_output_user_dir_rejects_existing_data() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let output_user_dir = temp_dir.path().join("branch-output").join("user");
+    fs::create_dir_all(&output_user_dir).expect("Failed to create output dir");
+    fs::write(output_user_dir.join("data.mdb"), "stub").expect("Failed to write data.mdb");
+
+    let result = prepare_output_user_dir(&output_user_dir);
+    assert!(
+        result.is_err(),
+        "Expected error when output directory already exists"
+    );
+}

--- a/helix-cli/src/tests/branch_tests.rs
+++ b/helix-cli/src/tests/branch_tests.rs
@@ -26,34 +26,22 @@ fn setup_test_project() -> (TempDir, ProjectContext) {
 #[test]
 fn test_resolve_output_dir_defaults() {
     let (_temp_dir, project) = setup_test_project();
-    let timestamp = "20240101-000000";
+    let branch_name = "branch-1";
 
-    let deploy_output = resolve_output_dir(&project, None, true, "branch-1", timestamp);
-    assert_eq!(
-        deploy_output,
-        project.helix_dir.join(".volumes").join("branch-1")
-    );
-
-    let branch_output = resolve_output_dir(&project, None, false, "", timestamp);
+    let branch_output = resolve_output_dir(&project, None, branch_name);
     assert_eq!(
         branch_output,
-        project
-            .helix_dir
-            .join(".branches")
-            .join(format!("branch-{timestamp}"))
+        project.helix_dir.join(".volumes").join(branch_name)
     );
 }
 
 #[test]
 fn test_resolve_output_dir_relative_path() {
     let (_temp_dir, project) = setup_test_project();
-    let timestamp = "20240101-000000";
     let output = resolve_output_dir(
         &project,
         Some(PathBuf::from("custom-output")),
-        false,
-        "",
-        timestamp,
+        "branch-1",
     );
     assert_eq!(output, project.root.join("custom-output"));
 }

--- a/helix-cli/src/tests/check_tests.rs
+++ b/helix-cli/src/tests/check_tests.rs
@@ -246,7 +246,7 @@ async fn test_check_with_multiple_instances() {
             port: Some(6970),
             build_mode: crate::config::BuildMode::Debug,
             db_config: DbConfig::default(),
-            
+            data_dir: None,
         },
     );
     config.local.insert(
@@ -255,7 +255,7 @@ async fn test_check_with_multiple_instances() {
             port: Some(6971),
             build_mode: crate::config::BuildMode::Debug,
             db_config: DbConfig::default(),
-            
+            data_dir: None,
         },
     );
     let config_path = project_path.join("helix.toml");

--- a/helix-cli/src/tests/mod.rs
+++ b/helix-cli/src/tests/mod.rs
@@ -5,6 +5,8 @@ pub mod init_tests;
 pub mod check_tests;
 #[cfg(test)]
 pub mod compile_tests;
+#[cfg(test)]
+pub mod branch_tests;
 // #[cfg(test)]
 // pub mod build_tests;
 // #[cfg(test)]

--- a/helix-cli/src/tests/mod.rs
+++ b/helix-cli/src/tests/mod.rs
@@ -7,6 +7,8 @@ pub mod check_tests;
 pub mod compile_tests;
 #[cfg(test)]
 pub mod branch_tests;
+#[cfg(test)]
+pub mod backup_tests;
 // #[cfg(test)]
 // pub mod build_tests;
 // #[cfg(test)]


### PR DESCRIPTION
## Description
- Add `helix branch` to snapshot local LMDB data into a new directory (with optional deploy), with safe overwrite prompts and default `.helix/.branches` output.
- Persist per-instance `data_dir` in `helix.toml` and use it for backup/start/push/delete output and Docker volume mounts.
- Add repo-cache locking (process + file lock) in build/check flows and support `HELIX_CACHE_DIR` plus test-safe cache roots.
- Add new `fs2` dependency in `helix-cli` for cross-process file locking.
- Update CLI docs (`helix-cli/README.md`) and contributor command list (`CONTRIBUTORS.md`).
- Add branch command unit tests.
- Normalize and quote Windows absolute volume paths in docker compose generation to avoid `C:` parsing issues ('src/docker.rs').

## Related Issues
#787.

## Checklist when merging to main
- [x] No compiler warnings (if applicable)
- [x] Code is formatted with `rustfmt`
- [x] No useless or dead code (if applicable)
- [x] Code is easy to understand
- [x] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [x] All tests pass
- [x] Performance has not regressed (assuming change was not to fix a bug)
- [x] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
Cache behavior:
- `HELIX_CACHE_DIR` overrides the default repo cache location for build/check flows.
- Tests use a temp per-thread cache root to avoid collisions with user caches.
- Repo-cache operations are serialized to avoid concurrent cache mutations.
Dependency note:
- `helix-cli` now depends on `fs2` for file locking.
- Windows absolute paths are normalized to `/` separators and quoted in `host:container` volume specs.

## Tests
Tests are passing.

### Tests Added
- `helix-cli/src/tests/branch_tests.rs`
  - `test_resolve_output_dir_defaults`
  - `test_resolve_output_dir_relative_path`
  - `test_branch_persists_deploy_config`
  - `test_prepare_output_user_dir_rejects_existing_data`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR implements the `helix branch` command to safely clone LMDB databases for local instances, with optional deployment. The implementation reuses existing LMDB `env.copy_to_path()` logic from the backup command.

## Key Changes

- **Branch Command**: Creates atomic LMDB snapshots to `.helix/.branches/<timestamp>` (default). Includes overwrite protection with interactive prompts and size warnings for databases >10GB.

- **Data Directory Persistence**: Added optional `data_dir` field to `LocalInstanceConfig` in `helix.toml`, enabling custom data locations. Commands like `start`, `delete`, and `backup` now respect this configuration.

- **Cache Locking**: Implemented dual-locking (in-process `Mutex` + cross-process file lock via `fs2`) for the Helix repo cache in `build` and `check` commands. Prevents concurrent cache mutations and supports `HELIX_CACHE_DIR` override.

- **Windows Path Handling**: Normalized and quoted Windows absolute paths in Docker Compose volume specs to avoid `C:` parsing issues (`"C:/path:/data"` format).

- **Test Isolation**: Tests now use per-thread, per-process temporary cache directories to avoid conflicts with user caches.

## Testing

Four unit tests added covering output directory resolution, config persistence, and overwrite protection.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-cli/src/commands/branch.rs | New branch command implementation - safely copies LMDB data and optionally deploys new instance |
| helix-cli/src/commands/build.rs | Added process and file locking for repo cache operations to prevent concurrent mutations |
| helix-cli/src/docker.rs | Windows path normalization for Docker volumes - quotes and normalizes absolute paths with colons |
| helix-cli/src/config.rs | Added optional data_dir field to LocalInstanceConfig with path serialization support |
| helix-cli/src/project.rs | Added HELIX_CACHE_DIR env var support and thread-safe test cache isolation |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as helix branch
    participant Project as ProjectContext
    participant Config as helix.toml
    participant LMDB as LMDB Env
    participant Docker as DockerManager
    participant Build as build::run

    User->>CLI: helix branch <instance> [--deploy] [--name <name>]
    CLI->>Project: find_and_load()
    Project->>Config: load instance config
    Config-->>CLI: LocalInstanceConfig
    
    CLI->>CLI: resolve_output_dir()
    Note over CLI: Default: .helix/.branches/<timestamp><br/>or .helix/.volumes/<branch-name> if --deploy
    
    CLI->>CLI: prepare_output_user_dir()
    alt Directory exists with data
        CLI->>User: Prompt for overwrite confirmation
        User-->>CLI: Confirm/Cancel
    end
    
    CLI->>LMDB: Open read-only snapshot
    LMDB-->>CLI: Environment handle
    CLI->>LMDB: copy_to_path(output_dir/user/data.mdb)
    LMDB-->>CLI: Atomic copy complete
    
    alt --deploy flag set
        CLI->>CLI: select_available_port()
        CLI->>Config: persist_branch_config()
        Note over Config: Add new instance with data_dir
        Config->>Config: save helix.toml
        
        CLI->>Docker: check_runtime_available()
        CLI->>Build: run(branch_name)
        Note over Build: Builds Docker image<br/>with branched data
        Build-->>CLI: Build complete
        
        CLI->>Docker: start_instance(branch_name)
        Docker-->>CLI: Container running
        CLI->>User: Display connection info
    end
    
    CLI-->>User: Branch created successfully
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->