### PR TITLE
Update helix-cli/build.sh

### DIFF
--- a/helix-cli/build.sh
+++ b/helix-cli/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Check if Rust is installed
-if ! command -v rustc &> /dev/null
+# Check if Cargo is installed
+if ! command -v cargo &> /dev/null
 then
     echo "Rust is not installed. Installing Rust..."
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -13,11 +13,6 @@ else
     echo "Rust is already installed. Skipping installation."
 fi
 
-# Ensure cargo is in PATH
-export PATH="$HOME/.cargo/bin:$PATH"
-
-# Continue with build process
-
 # if dev profile, build with dev profile
 if [ "$1" = "dev" ]; then
     cargo build --profile dev && cargo install --profile dev --path . --root ~/.local
@@ -27,13 +22,8 @@ else
     cargo build --release && cargo install --path . --root ~/.local
 fi
 
+# Add helix installation path to $PATH 
 if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
-    if ! grep -Fxq 'export PATH="$HOME/.local/bin:$PATH"' ~/.bashrc; then
-        echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
-    fi
-    if ! grep -Fxq 'export PATH="$HOME/.local/bin:$PATH"' ~/.zshrc; then
-        echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
-    fi
     export PATH="$HOME/.local/bin:$PATH"
 fi
 


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Improved the build script by checking for `cargo` directly instead of `rustc`, and simplified PATH management by removing persistent shell config modifications.

## Key Changes
- Changed dependency check from `rustc` to `cargo` (more accurate since the script uses `cargo`)
- Removed redundant `PATH` export after the Rust installation block
- Removed automatic modifications to `~/.bashrc` and `~/.zshrc` files
- Only sets `PATH` for the current session instead of persisting changes to shell config files

## Issues Found
- **Critical syntax error**: Line 4 uses bash-specific `&>` redirection with POSIX `sh` shebang, which will fail on systems where `/bin/sh` is not bash (e.g., Ubuntu/Debian with dash). Must use `>/dev/null 2>&1` instead.

## Notes
- The changes align with the principle of minimal system modification - the script now only affects the current terminal session
- Removing persistent shell modifications is cleaner but means users must manually add `~/.local/bin` to their PATH if they want it available in future sessions
- The `install.sh` script still handles persistent PATH configuration, which is the appropriate place for that functionality

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-cli/build.sh | 3/5 | Changed Rust check from `rustc` to `cargo`, removed shell config file modifications. Critical issue: non-POSIX `&>` syntax used with sh shebang. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant BuildScript as build.sh
    participant System
    participant Cargo
    participant Shell
    
    User->>BuildScript: Execute build.sh [dev|offline|release]
    BuildScript->>System: Check if cargo is installed
    
    alt cargo not found
        BuildScript->>System: Download rustup installer
        System-->>BuildScript: Installer script
        BuildScript->>System: Execute rustup with -y flag
        System->>Cargo: Install Rust toolchain
        BuildScript->>Shell: Export PATH=$HOME/.cargo/bin:$PATH
        BuildScript->>Shell: Source $HOME/.cargo/env
        BuildScript->>Cargo: Run cargo update
    else cargo exists
        BuildScript->>BuildScript: Skip Rust installation
    end
    
    alt dev profile
        BuildScript->>Cargo: cargo build --profile dev
        BuildScript->>Cargo: cargo install --profile dev --path . --root ~/.local
    else offline profile
        BuildScript->>Cargo: cargo build --profile dev --offline
        BuildScript->>Cargo: cargo install --profile dev --offline --path . --root ~/.local
    else release (default)
        BuildScript->>Cargo: cargo build --release
        BuildScript->>Cargo: cargo install --path . --root ~/.local
    end
    
    BuildScript->>System: Check if $HOME/.local/bin in PATH
    alt Not in PATH
        BuildScript->>Shell: Export PATH=$HOME/.local/bin:$PATH
    end
    
    BuildScript-->>User: Build complete
```
</details>
