### PR TITLE
fix(cli): removing region

### DIFF
--- a/helix-cli/src/commands/add.rs
+++ b/helix-cli/src/commands/add.rs
@@ -96,13 +96,13 @@ async fn run_add_inner(
     // Determine instance type
 
     match deployment_type {
-        CloudDeploymentTypeCommand::Helix { region, .. } => {
+        CloudDeploymentTypeCommand::Helix { .. } => {
             // Add Helix cloud instance
             let helix_manager = HelixManager::new(&project_context);
 
             // Create cloud instance configuration (without cluster_id yet)
             let cloud_config = helix_manager
-                .create_instance_config(&instance_name, region.clone())
+                .create_instance_config(&instance_name)
                 .await?;
 
             // Insert into project configuration
@@ -136,7 +136,7 @@ async fn run_add_inner(
 
             if should_create {
                 // Run create-cluster flow
-                crate::commands::create_cluster::run(&instance_name, region).await?;
+                crate::commands::create_cluster::run(&instance_name).await?;
 
                 // create_cluster::run() already saved the updated config with the real cluster_id
                 // Return early to avoid overwriting it with the stale in-memory config

--- a/helix-cli/src/commands/create_cluster.rs
+++ b/helix-cli/src/commands/create_cluster.rs
@@ -9,7 +9,7 @@ use crate::{
 use eyre::{OptionExt, Result, eyre};
 
 /// Create a new cluster in Helix Cloud
-pub async fn run(instance_name: &str, region: Option<String>) -> Result<()> {
+pub async fn run(instance_name: &str) -> Result<()> {
     print_status("CREATE", &format!("Creating cluster: {}", instance_name));
 
     // Load project context
@@ -37,9 +37,6 @@ pub async fn run(instance_name: &str, region: Option<String>) -> Result<()> {
 
     // Check authentication
     let credentials = require_auth().await?;
-
-    // Get or default region
-    let region = region.unwrap_or_else(|| "us-east-1".to_string());
 
     // Connect to SSE stream for cluster creation
     // The server will send CheckoutRequired, PaymentConfirmed, CreatingProject, ProjectCreated events
@@ -130,7 +127,7 @@ pub async fn run(instance_name: &str, region: Option<String>) -> Result<()> {
     {
         CloudInstanceConfig {
             cluster_id: cluster_id.clone(),
-            region: existing.region.clone().or(Some(region.clone())),
+            region: existing.region.clone(),
             build_mode: existing.build_mode,
             env_vars: existing.env_vars.clone(),
             db_config: existing.db_config.clone(),
@@ -138,7 +135,7 @@ pub async fn run(instance_name: &str, region: Option<String>) -> Result<()> {
     } else {
         CloudInstanceConfig {
             cluster_id: cluster_id.clone(),
-            region: Some(region.clone()),
+            region: None,
             build_mode: crate::config::BuildMode::Release,
             env_vars: std::collections::HashMap::new(),
             db_config: DbConfig::default(),
@@ -160,7 +157,6 @@ pub async fn run(instance_name: &str, region: Option<String>) -> Result<()> {
         "Cluster '{}' created successfully! (ID: {})",
         instance_name, cluster_id
     ));
-    print_info(&format!("Region: {}", region));
     print_info("Configuration saved to helix.toml");
     print_info(&format!(
         "You can now deploy with: helix push {}",

--- a/helix-cli/src/commands/init.rs
+++ b/helix-cli/src/commands/init.rs
@@ -113,7 +113,7 @@ async fn run_init_inner(
     match deployment_type {
         Some(deployment) => {
             match deployment {
-                CloudDeploymentTypeCommand::Helix { region, .. } => {
+                CloudDeploymentTypeCommand::Helix { .. } => {
                     // Initialize Helix deployment
                     let cwd = env::current_dir()?;
                     let project_context = ProjectContext::find_and_load(Some(&cwd))?;
@@ -123,7 +123,7 @@ async fn run_init_inner(
 
                     // Create cloud instance configuration (without cluster_id yet)
                     let cloud_config = helix_manager
-                        .create_instance_config(project_name, region.clone())
+                        .create_instance_config(project_name)
                         .await?;
 
                     // Insert into config first
@@ -158,7 +158,7 @@ async fn run_init_inner(
 
                     if should_create {
                         // Run create-cluster flow
-                        crate::commands::create_cluster::run(project_name, region).await?;
+                        crate::commands::create_cluster::run(project_name).await?;
                     } else {
                         println!();
                         print_status(

--- a/helix-cli/src/commands/integrations/helix.rs
+++ b/helix-cli/src/commands/integrations/helix.rs
@@ -37,18 +37,14 @@ impl<'a> HelixManager<'a> {
     pub async fn create_instance_config(
         &self,
         _instance_name: &str,
-        region: Option<String>,
     ) -> Result<CloudInstanceConfig> {
         // Generate unique cluster ID
         // let cluster_id = format!("helix-{}-{}", instance_name, Uuid::new_v4());
         let cluster_id = "YOUR_CLUSTER_ID".to_string();
 
-        // Use provided region or default to us-east-1
-        let region = region.or_else(|| Some("us-east-1".to_string()));
-
         Ok(CloudInstanceConfig {
             cluster_id,
-            region,
+            region: None,
             build_mode: BuildMode::Release,
             env_vars: HashMap::new(),
             db_config: DbConfig::default(),

--- a/helix-cli/src/lib.rs
+++ b/helix-cli/src/lib.rs
@@ -77,10 +77,6 @@ pub enum CloudDeploymentTypeCommand {
     /// Initialize Helix Cloud deployment
     #[clap(name = "cloud")]
     Helix {
-        /// Region for Helix cloud instance (default: us-east-1)
-        #[clap(long, default_value = "us-east-1")]
-        region: Option<String>,
-
         /// Instance name
         #[clap(short, long)]
         name: Option<String>,

--- a/helix-cli/src/main.rs
+++ b/helix-cli/src/main.rs
@@ -53,10 +53,6 @@ enum Commands {
     CreateCluster {
         /// Instance name
         instance: String,
-
-        /// Region for cluster (defaults to us-east-1)
-        #[clap(short, long)]
-        region: Option<String>,
     },
 
     /// Validate project configuration and queries
@@ -221,8 +217,8 @@ async fn main() -> Result<()> {
             cloud,
         } => commands::init::run(path, template, queries_path, cloud).await,
         Commands::Add { cloud } => commands::add::run(cloud).await,
-        Commands::CreateCluster { instance, region } => {
-            commands::create_cluster::run(&instance, region).await
+        Commands::CreateCluster { instance } => {
+            commands::create_cluster::run(&instance).await
         }
         Commands::Check { instance } => commands::check::run(instance, &metrics_sender).await,
         Commands::Compile { output, path } => commands::compile::run(output, path).await,

--- a/helix-cli/src/prompts.rs
+++ b/helix-cli/src/prompts.rs
@@ -18,25 +18,6 @@ pub enum DeploymentType {
     Fly,
 }
 
-/// AWS/Helix Cloud region options
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Region {
-    UsEast1,
-    UsWest2,
-    EuWest1,
-    ApSoutheast1,
-}
-
-impl Region {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Region::UsEast1 => "us-east-1",
-            Region::UsWest2 => "us-west-2",
-            Region::EuWest1 => "eu-west-1",
-            Region::ApSoutheast1 => "ap-southeast-1",
-        }
-    }
-}
 
 /// Show the intro banner for interactive mode
 pub fn intro(title: &str, subheader: Option<&str>) -> Result<()> {
@@ -94,26 +75,6 @@ pub fn select_deployment_type() -> Result<DeploymentType> {
         .interact()?;
 
     Ok(selected)
-}
-
-/// Prompt user to select a cloud region
-pub fn select_region() -> Result<String> {
-    let selected: Region = cliclack::select("Select a region")
-        .item(
-            Region::UsEast1,
-            "us-east-1",
-            "N. Virginia - Lowest latency for US East",
-        )
-        .item(Region::UsWest2, "us-west-2", "Oregon - US West Coast")
-        .item(Region::EuWest1, "eu-west-1", "Ireland - Europe")
-        .item(
-            Region::ApSoutheast1,
-            "ap-southeast-1",
-            "Singapore - Asia Pacific",
-        )
-        .interact()?;
-
-    Ok(selected.as_str().to_string())
 }
 
 /// Prompt user to select a Fly.io VM size
@@ -212,10 +173,7 @@ pub async fn build_deployment_command(
             name: Some(instance_name),
         })),
         DeploymentType::HelixCloud => {
-            // Check auth early for Helix Cloud instances
-            let region = select_region()?;
             Ok(Some(CloudDeploymentTypeCommand::Helix {
-                region: Some(region),
                 name: Some(instance_name),
             }))
         }
@@ -253,11 +211,7 @@ pub async fn build_init_deployment_command() -> Result<Option<CloudDeploymentTyp
             Ok(None)
         }
         DeploymentType::HelixCloud => {
-            let region = select_region()?;
-            Ok(Some(CloudDeploymentTypeCommand::Helix {
-                region: Some(region),
-                name: None,
-            }))
+            Ok(Some(CloudDeploymentTypeCommand::Helix { name: None }))
         }
         DeploymentType::Ecr => Ok(Some(CloudDeploymentTypeCommand::Ecr { name: None })),
         DeploymentType::Fly => {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR removes the `region` parameter from Helix Cloud deployment configuration across the CLI. The changes are well-executed and consistent across all affected files.

## What Changed

- **CLI Interface**: Removed the `--region` flag from `helix init cloud` and `helix create-cluster` commands
- **Interactive Prompts**: Removed the `Region` enum and `select_region()` function that previously prompted users to choose between us-east-1, us-west-2, eu-west-1, and ap-southeast-1
- **Configuration**: New Helix Cloud instances now have `region: None` instead of defaulting to "us-east-1"
- **Backward Compatibility**: The `region` field remains in `CloudInstanceConfig` as `Option<String>` to support existing configurations

## Code Quality

The implementation is clean and thorough:
- All function signatures updated consistently across 7 files
- The region field is properly preserved when updating existing configurations (see `create_cluster.rs` line 130)
- No dead code left behind - the entire region selection flow was cleanly removed
- Backward compatibility maintained through `#[serde(default)]` annotation

## Issue Found

One documentation file needs updating: `TESTING.md` still references the removed `--cloud-region` flag (line 44).

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-cli/src/lib.rs | 5/5 | Cleanly removed region field from CloudDeploymentTypeCommand::Helix enum variant |
| helix-cli/src/main.rs | 5/5 | Removed region parameter from CreateCluster command definition and usage |
| helix-cli/src/prompts.rs | 5/5 | Removed Region enum, select_region function, and all region selection prompts |
| helix-cli/src/commands/integrations/helix.rs | 5/5 | Updated create_instance_config to set region to None, removed region parameter |
| helix-cli/src/commands/create_cluster.rs | 5/5 | Removed region parameter from function, removed region defaulting logic and output message, preserves existing region from configs |
| helix-cli/src/commands/add.rs | 5/5 | Updated calls to create_instance_config and create_cluster::run to not pass region |
| helix-cli/src/commands/init.rs | 5/5 | Updated calls to create_instance_config and create_cluster::run to not pass region |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as helix init/add
    participant Prompts as prompts.rs
    participant Helix as helix.rs
    participant CreateCluster as create_cluster.rs
    participant Config as helix.toml

    User->>CLI: helix init cloud
    CLI->>Prompts: build_init_deployment_command()
    Note over Prompts: NO LONGER prompts<br/>for region selection
    Prompts-->>CLI: CloudDeploymentTypeCommand::Helix
    CLI->>Helix: create_instance_config(name)
    Note over Helix: Sets region: None<br/>(was region: Some(selected))
    Helix-->>CLI: CloudInstanceConfig
    CLI->>Config: Save config with region: None
    CLI->>CreateCluster: run(instance_name)
    Note over CreateCluster: No region parameter<br/>(was region: Option<String>)
    CreateCluster->>CreateCluster: Preserve existing region if any
    CreateCluster->>Config: Update with cluster_id
    CreateCluster-->>CLI: Success
    CLI-->>User: Cluster created (no region displayed)
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->