### PR TITLE
Only push to S3 when release is on main

### DIFF
--- a/.github/workflows/s3_push.yml
+++ b/.github/workflows/s3_push.yml
@@ -20,17 +20,26 @@ jobs:
           fetch-depth: 0
 
       - name: Verify release is from main branch
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         run: |
-          # Get the commit SHA for the release tag
-          TAG_COMMIT=$(git rev-list -n 1 ${{ github.event.release.tag_name }})
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # Get the commit SHA for the release tag
+            TAG_COMMIT=$(git rev-list -n 1 ${{ github.event.release.tag_name }})
 
-          # Check if this commit is on the main branch
-          if git merge-base --is-ancestor $TAG_COMMIT origin/main; then
-            echo "Tag ${{ github.event.release.tag_name }} is on main branch"
-          else
-            echo "Tag ${{ github.event.release.tag_name }} is NOT on main branch, skipping S3 push"
-            exit 1
+            # Check if this commit is on the main branch
+            if git merge-base --is-ancestor $TAG_COMMIT origin/main; then
+              echo "Tag ${{ github.event.release.tag_name }} is on main branch"
+            else
+              echo "Tag ${{ github.event.release.tag_name }} is NOT on main branch, skipping S3 push"
+              exit 1
+            fi
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+              echo "workflow_dispatch triggered from main branch"
+            else
+              echo "workflow_dispatch must be run from main branch, not ${{ github.ref }}"
+              exit 1
+            fi
           fi
 
       - name: Configure AWS credentials using OIDC


### PR DESCRIPTION
Only push to S3 when a release is created on main

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR modifies the S3 push workflow to enforce that releases can only trigger S3 uploads when they originate from the main branch. The changes achieve this by:

1. **Removing the `create.tags` trigger** - Previously, any tag creation (matching `v*`) would trigger the workflow. This has been removed to rely solely on release events.

2. **Adding branch verification logic** - A new step verifies that:
   - For release events: The tagged commit must be an ancestor of `origin/main` (using `git merge-base --is-ancestor`)
   - For workflow_dispatch events: The workflow must be triggered from the `refs/heads/main` branch

3. **Adding `fetch-depth: 0`** - Required to enable the git history commands needed for branch verification.

## Key Changes
- Removed trigger: `on.create.tags`
- Added verification step that exits with code 1 if the release/dispatch is not from main
- The workflow will now fail early (before AWS authentication) if triggered from non-main branches

## Issues Found
The implementation has **no critical bugs** but includes several shell scripting best practice violations:
- Missing quotes around GitHub context variables in shell commands
- No validation that `TAG_COMMIT` variable is non-empty before use
- Redundant conditional that checks for event types that are the only triggers

These are style/robustness improvements rather than functional issues. The core logic correctly implements the intended security control of restricting S3 uploads to main branch releases.

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/s3_push.yml | 4/5 | Modified to verify releases are from main branch before S3 push. Removed tag creation trigger. Found shell script best practice issues with variable quoting and missing error handling. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant GitHub
    participant Workflow as S3 Push Workflow
    participant Git
    participant AWS as AWS S3

    alt Release Event (published/created)
        User->>GitHub: Create/Publish Release
        GitHub->>Workflow: Trigger workflow (release event)
        Workflow->>Git: Checkout repository (fetch-depth: 0)
        Git-->>Workflow: Repository checked out
        Workflow->>Git: Get commit SHA for release tag
        Git-->>Workflow: TAG_COMMIT
        Workflow->>Git: Check if TAG_COMMIT is ancestor of origin/main
        alt Tag is on main branch
            Git-->>Workflow: Success (exit 0)
            Workflow->>AWS: Configure AWS credentials via OIDC
            AWS-->>Workflow: Credentials configured
            Workflow->>Workflow: Create template.tar.gz
            Workflow->>AWS: Upload template.tar.gz to S3
            AWS-->>Workflow: Upload complete
            Workflow->>User: Success notification
        else Tag is NOT on main branch
            Git-->>Workflow: Failure (exit 1)
            Workflow->>User: Skip S3 push - not on main
        end
    else Manual Trigger (workflow_dispatch)
        User->>GitHub: Manually trigger workflow
        GitHub->>Workflow: Trigger workflow (workflow_dispatch event)
        Workflow->>Git: Checkout repository (fetch-depth: 0)
        Git-->>Workflow: Repository checked out
        alt Triggered from main branch
            Workflow->>AWS: Configure AWS credentials via OIDC
            AWS-->>Workflow: Credentials configured
            Workflow->>Workflow: Create template.tar.gz
            Workflow->>AWS: Upload template.tar.gz to S3
            AWS-->>Workflow: Upload complete
            Workflow->>User: Success notification
        else Triggered from non-main branch
            Workflow->>User: Error - must run from main
        end
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->