### PR TITLE
implementing upsert fix

### DIFF
--- a/helix-db/src/helix_engine/vector_core/vector_core.rs
+++ b/helix-db/src/helix_engine/vector_core/vector_core.rs
@@ -130,11 +130,7 @@ impl VectorCore {
             let mut arr = [0u8; 16];
             let len = std::cmp::min(ep_id.len(), 16);
             arr[..len].copy_from_slice(&ep_id[..len]);
-
-            let ep = self
-                .get_raw_vector_data(txn, u128::from_be_bytes(arr), label, arena)
-                .map_err(|_| VectorError::EntryPointNotFound)?;
-            Ok(ep)
+            self.get_raw_vector_data(txn, u128::from_be_bytes(arr), label, arena)
         } else {
             Err(VectorError::EntryPointNotFound)
         }
@@ -442,7 +438,7 @@ impl VectorCore {
         let vector_data_bytes = self
             .vectors_db
             .get(txn, &Self::vector_key(id, 0))?
-            .ok_or(VectorError::VectorNotFound(uuid_str(id, arena).to_string()))?;
+            .ok_or(VectorError::EntryPointNotFound)?;
         HVector::from_raw_vector_data(arena, vector_data_bytes, label, id)
     }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

Fixed critical bug where `upsert_v` created vectors that weren't searchable because they bypassed HNSW index insertion. Now uses proper `insert` method to integrate vectors into the HNSW graph structure.

**Key Changes:**
- Replaced manual `HVector` creation and `put_vector` with `VectorCore::insert` method in `upsert_v` when creating new vectors
- `insert` method properly adds vectors to HNSW graph with neighbor connections at all levels
- Reorganized error handling flow to check `result.is_ok()` before processing secondary indices and BM25
- Added test `test_upsert_v_new_vector_is_searchable` to verify upserted vectors can be found via `search_v`
- Cleaned up redundant error handling code in `vector_core.rs`
- Improved code formatting by removing unnecessary braces in match expressions

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| helix-db/src/helix_engine/traversal_core/ops/util/upsert.rs | 5/5 | Replaced manual vector creation with HNSW insert method for proper index integration; improved error handling flow |
| helix-db/src/helix_engine/tests/traversal_tests/upsert_tests.rs | 5/5 | Added test to verify upserted vectors are searchable via HNSW index; validates the fix works correctly |
| helix-db/src/helix_engine/vector_core/vector_core.rs | 5/5 | Simplified error handling in get_entry_point and get_raw_vector_data by removing redundant code |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant UpsertAdapter
    participant VectorCore
    participant HNSW
    participant Database

    Note over Client,Database: Upsert Vector Flow (New Implementation)
    
    Client->>UpsertAdapter: upsert_v(query, label, props)
    UpsertAdapter->>UpsertAdapter: Check if vector exists in iterator
    
    alt Vector does not exist (None case)
        UpsertAdapter->>UpsertAdapter: Create properties map
        UpsertAdapter->>VectorCore: insert(txn, label, query, properties, arena)
        VectorCore->>HNSW: Generate new level
        VectorCore->>HNSW: Create HVector with properties
        VectorCore->>Database: put_vector(txn, vector)
        HNSW->>Database: Insert into HNSW graph structure
        HNSW->>Database: Create neighbor connections at all levels
        HNSW-->>VectorCore: Return indexed vector
        VectorCore-->>UpsertAdapter: Return vector
        UpsertAdapter->>Database: Add secondary indices for properties
        UpsertAdapter->>Database: Add BM25 index if enabled
        UpsertAdapter-->>Client: Return TraversalValue::Vector
    else Vector exists (Some case)
        UpsertAdapter->>UpsertAdapter: Update properties
        UpsertAdapter->>Database: Update secondary indices
        UpsertAdapter->>VectorCore: put_vector(txn, vector)
        VectorCore->>Database: Store updated vector data
        UpsertAdapter->>Database: Update BM25 index if enabled
        UpsertAdapter-->>Client: Return TraversalValue::Vector
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->