### PR TITLE
bug (hql): rust generation failure - error[E0507]: cannot move out of…

### DIFF
--- a/helix-db/src/helixc/generator/source_steps.rs
+++ b/helix-db/src/helixc/generator/source_steps.rs
@@ -116,7 +116,7 @@ impl Display for AddE {
                 // From is plural - iterate over from, to already has .id()
                 write!(
                     f,
-                    "{}.iter().map(|from_val| {{\n        G::new_mut(&db, &arena, &mut txn)\n        .add_edge({}, {}, from_val.id(), {}, false, {})\n        .collect_to_obj()\n    }}).collect::<Result<Vec<_>,_>>()?",
+                    "{{\n    let mut edge = Vec::new();\n    for from_val in {}.iter() {{\n        let e = G::new_mut(&db, &arena, &mut txn)\n            .add_edge({}, {}, from_val.id(), {}, false, {})\n            .collect_to_obj()?;\n        edge.push(e);\n    }}\n    edge\n}}",
                     self.from,
                     self.label,
                     write_properties(&self.properties),
@@ -128,7 +128,7 @@ impl Display for AddE {
                 // To is plural - iterate over to, from already has .id()
                 write!(
                     f,
-                    "{}.iter().map(|to_val| {{\n        G::new_mut(&db, &arena, &mut txn)\n        .add_edge({}, {}, {}, to_val.id(), false, {})\n        .collect_to_obj()\n    }}).collect::<Result<Vec<_>,_>>()?",
+                    "{{\n    let mut edge = Vec::new();\n    for to_val in {}.iter() {{\n        let e = G::new_mut(&db, &arena, &mut txn)\n            .add_edge({}, {}, {}, to_val.id(), false, {})\n            .collect_to_obj()?;\n        edge.push(e);\n    }}\n    edge\n}}",
                     self.to,
                     self.label,
                     write_properties(&self.properties),
@@ -140,7 +140,7 @@ impl Display for AddE {
                 // Both plural - nested iteration
                 write!(
                     f,
-                    "{}.iter().flat_map(|from_val| {{\n        {}.iter().map(move |to_val| {{\n            G::new_mut(&db, &arena, &mut txn)\n            .add_edge({}, {}, from_val.id(), to_val.id(), false, {})\n            .collect_to_obj()\n        }})\n    }}).collect::<Result<Vec<_>,_>>()?",
+                    "{{\n    let mut edge = Vec::new();\n    for from_val in {}.iter() {{\n        for to_val in {}.iter() {{\n            let e = G::new_mut(&db, &arena, &mut txn)\n                .add_edge({}, {}, from_val.id(), to_val.id(), false, {})\n                .collect_to_obj()?;\n            edge.push(e);\n        }}\n    }}\n    edge\n}}",
                     self.from,
                     self.to,
                     self.label,
@@ -217,7 +217,7 @@ impl Display for UpsertE {
                 // From is plural - iterate over from, to already has .id()
                 write!(
                     f,
-                    "{}.iter().map(|from_val| {{\n        G::new_mut(&db, &arena, &mut txn)\n        .upsert_e({}, from_val.id(), {}, {})\n        .collect_to_obj()\n    }}).collect::<Result<Vec<_>,_>>()?",
+                    "{{\n    let mut edge = Vec::new();\n    for from_val in {}.iter() {{\n        let e = G::new_mut(&db, &arena, &mut txn)\n            .upsert_e({}, from_val.id(), {}, {})\n            .collect_to_obj()?;\n        edge.push(e);\n    }}\n    edge\n}}",
                     self.from,
                     self.label,
                     self.to,
@@ -228,7 +228,7 @@ impl Display for UpsertE {
                 // To is plural - iterate over to, from already has .id()
                 write!(
                     f,
-                    "{}.iter().map(|to_val| {{\n        G::new_mut(&db, &arena, &mut txn)\n        .upsert_e({}, {}, to_val.id(), {})\n        .collect_to_obj()\n    }}).collect::<Result<Vec<_>,_>>()?",
+                    "{{\n    let mut edge = Vec::new();\n    for to_val in {}.iter() {{\n        let e = G::new_mut(&db, &arena, &mut txn)\n            .upsert_e({}, {}, to_val.id(), {})\n            .collect_to_obj()?;\n        edge.push(e);\n    }}\n    edge\n}}",
                     self.to,
                     self.label,
                     self.from,
@@ -239,7 +239,7 @@ impl Display for UpsertE {
                 // Both plural - nested iteration
                 write!(
                     f,
-                    "{}.iter().flat_map(|from_val| {{\n        {}.iter().map(move |to_val| {{\n            G::new_mut(&db, &arena, &mut txn)\n            .upsert_e({}, from_val.id(), to_val.id(), {})\n            .collect_to_obj()\n        }})\n    }}).collect::<Result<Vec<_>,_>>()?",
+                    "{{\n    let mut edge = Vec::new();\n    for from_val in {}.iter() {{\n        for to_val in {}.iter() {{\n            let e = G::new_mut(&db, &arena, &mut txn)\n                .upsert_e({}, from_val.id(), to_val.id(), {})\n                .collect_to_obj()?;\n            edge.push(e);\n        }}\n    }}\n    edge\n}}",
                     self.from,
                     self.to,
                     self.label,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed Rust compilation error E0507 in generated code by replacing functional iterator chains with imperative for loops.

**Changes Made:**
- Replaced `.iter().map()` patterns with explicit `for` loops in `AddE::Display` implementation (3 cases)
- Replaced `.iter().flat_map().map()` pattern with nested `for` loops in `AddE::Display` implementation
- Applied same transformation to `UpsertE::Display` implementation (3 cases total)
- All changes preserve identical functionality while avoiding ownership issues

**Technical Details:**
The original code attempted to move captured variables (`db`, `arena`, `txn`) inside `FnMut` closures created by `.map()`, which violates Rust's ownership rules. The imperative approach with `for` loops correctly borrows these variables without attempting to move them, resolving the compilation error while maintaining the same behavior of collecting edge results into a `Vec`.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-db/src/helixc/generator/source_steps.rs | Fixed Rust ownership issue by replacing .map()/.flat_map() with imperative for loops to avoid moving captured variables in FnMut closures |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant HQL as HelixQL Parser
    participant Gen as Code Generator
    participant Display as Display trait
    participant Rust as Generated Rust Code
    
    HQL->>Gen: Parse AddE or UpsertE with plural variables
    Gen->>Display: Call fmt method for code generation
    
    alt Both from and to are singular
        Display->>Rust: Generate single add_edge call
    else From is plural
        Display->>Rust: Generate for loop iterating over from
        Note over Rust: Creates Vec and pushes each edge result
    else To is plural
        Display->>Rust: Generate for loop iterating over to
        Note over Rust: Creates Vec and pushes each edge result
    else Both are plural
        Display->>Rust: Generate nested for loops
        Note over Rust: Creates Vec and pushes all combinations
    end
    
    Rust->>Rust: Execute with correct ownership semantics
    Note over Rust: For loops avoid FnMut closure ownership issues
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->