### PR TITLE
fix(oops): hotfix version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "helix-cli"
-version = "2.2.3"
+version = "2.2.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "helix-db"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/helix-cli/Cargo.toml
+++ b/helix-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-cli"
-version = "2.2.3"
+version = "2.2.4"
 edition = "2024"
 
 [dependencies]

--- a/helix-db/Cargo.toml
+++ b/helix-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-db"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2024"
 description = "HelixDB is a powerful, open-source, graph-vector database built in Rust for intelligent data storage for RAG and AI."
 license = "AGPL-3.0"

--- a/hql-tests/tests/docs_upsert_e/helix.toml
+++ b/hql-tests/tests/docs_upsert_e/helix.toml
@@ -1,0 +1,7 @@
+[project]
+name = "docs_upsert_e"
+queries = "."
+
+[local.dev]
+port = 6969
+build_mode = "dev"

--- a/hql-tests/tests/docs_upsert_e/queries.hx
+++ b/hql-tests/tests/docs_upsert_e/queries.hx
@@ -1,0 +1,39 @@
+// UpsertE documentation examples
+
+// Example 1: Basic edge upsert with properties
+QUERY UpsertFriendship(id1: ID, id2: ID, since: String) =>
+    person1 <- N<Person>(id1)
+    person2 <- N<Person>(id2)
+    existing <- E<Knows>
+    edge <- existing::UpsertE({since: since})::From(person1)::To(person2)
+    RETURN edge
+
+// Example 2: Upsert edge with multiple properties
+QUERY UpsertFriendshipWithProps(id1: ID, id2: ID, since: String, strength: F32) =>
+    person1 <- N<Person>(id1)
+    person2 <- N<Person>(id2)
+    existing <- E<Friendship>
+    edge <- existing::UpsertE({since: since, strength: strength})::From(person1)::To(person2)
+    RETURN edge
+
+// Example 3: Flexible From/To ordering
+QUERY UpsertEdgeToFrom(id1: ID, id2: ID, since: String) =>
+    person1 <- N<Person>(id1)
+    person2 <- N<Person>(id2)
+    existing <- E<Knows>
+    edge <- existing::UpsertE({since: since})::To(person2)::From(person1)
+    RETURN edge
+
+// Helper query to create persons
+QUERY CreatePerson(name: String, age: U32) =>
+    person <- AddN<Person>({name: name, age: age})
+    RETURN person
+
+// Helper query to get all edges
+QUERY GetAllKnows() =>
+    edges <- E<Knows>
+    RETURN edges
+
+QUERY GetAllFriendships() =>
+    edges <- E<Friendship>
+    RETURN edges

--- a/hql-tests/tests/docs_upsert_e/schema.hx
+++ b/hql-tests/tests/docs_upsert_e/schema.hx
@@ -1,0 +1,23 @@
+// UpsertE documentation schema
+
+N::Person {
+    INDEX name: String,
+    age: U32,
+}
+
+E::Knows {
+    From: Person,
+    To: Person,
+    Properties: {
+        since: String,
+    }
+}
+
+E::Friendship {
+    From: Person,
+    To: Person,
+    Properties: {
+        since: String,
+        strength: F32,
+    }
+}

--- a/hql-tests/tests/docs_upsert_n/helix.toml
+++ b/hql-tests/tests/docs_upsert_n/helix.toml
@@ -1,0 +1,7 @@
+[project]
+name = "docs_upsert_n"
+queries = "."
+
+[local.dev]
+port = 6969
+build_mode = "dev"

--- a/hql-tests/tests/docs_upsert_n/queries.hx
+++ b/hql-tests/tests/docs_upsert_n/queries.hx
@@ -1,0 +1,29 @@
+// UpsertN documentation examples
+
+// Example 1: Basic node upsert with properties
+QUERY UpsertPerson(name: String, age: U32) =>
+    existing <- N<Person>::WHERE(_::{name}::EQ(name))
+    person <- existing::UpsertN({name: name, age: age})
+    RETURN person
+
+// Example 2: Upsert from a pre-fetched node by ID
+QUERY UpsertPersonById(id: ID, new_age: U32) =>
+    existing <- N<Person>(id)
+    person <- existing::UpsertN({age: new_age})
+    RETURN person
+
+// Example 3: Upsert with WHERE filter
+QUERY UpdateOrCreatePerson(name: String, new_age: U32) =>
+    existing <- N<Person>::WHERE(_::{name}::EQ(name))
+    person <- existing::UpsertN({name: name, age: new_age})
+    RETURN person
+
+// Helper query to create persons for testing
+QUERY CreatePerson(name: String, age: U32) =>
+    person <- AddN<Person>({name: name, age: age})
+    RETURN person
+
+// Helper query to get all persons
+QUERY GetAllPersons() =>
+    persons <- N<Person>
+    RETURN persons

--- a/hql-tests/tests/docs_upsert_n/schema.hx
+++ b/hql-tests/tests/docs_upsert_n/schema.hx
@@ -1,0 +1,6 @@
+// UpsertN documentation schema
+
+N::Person {
+    INDEX name: String,
+    age: U32,
+}

--- a/hql-tests/tests/docs_upsert_v/config.hx.json
+++ b/hql-tests/tests/docs_upsert_v/config.hx.json
@@ -1,0 +1,12 @@
+{
+    "vector_config": {
+        "m": 16,
+        "ef_construction": 128,
+        "ef_search": 768,
+        "db_max_size": 20
+    },
+    "graph_config": {
+        "secondary_indices": []
+    },
+    "db_max_size_gb": 20
+}

--- a/hql-tests/tests/docs_upsert_v/helix.toml
+++ b/hql-tests/tests/docs_upsert_v/helix.toml
@@ -1,0 +1,7 @@
+[project]
+name = "docs_upsert_v"
+queries = "."
+
+[local.dev]
+port = 6969
+build_mode = "dev"

--- a/hql-tests/tests/docs_upsert_v/queries.hx
+++ b/hql-tests/tests/docs_upsert_v/queries.hx
@@ -1,0 +1,41 @@
+// UpsertV documentation examples
+
+// Example 1: Basic vector upsert with properties
+QUERY UpsertDoc(vector: [F64], content: String) =>
+    existing <- V<Document>::WHERE(_::{content}::EQ(content))
+    doc <- existing::UpsertV(vector, {content: content})
+    RETURN doc
+
+// Example 2: Upsert vector using the Embed function
+QUERY UpsertDocEmbed(text: String) =>
+    existing <- V<Document>::WHERE(_::{content}::EQ(text))
+    doc <- existing::UpsertV(Embed(text), {content: text})
+    RETURN doc
+
+// Example 3: Complex operation with nodes, edges, and vectors
+QUERY ComplexUpsertOperation(
+    person_name: String,
+    person_age: U32,
+    company_name: String,
+    position: String,
+    resume_content: String
+) =>
+    existing_person <- N<Person>::WHERE(_::{name}::EQ(person_name))
+    person <- existing_person::UpsertN({name: person_name, age: person_age})
+    existing_company <- N<Company>::WHERE(_::{name}::EQ(company_name))
+    company <- existing_company::UpsertN({name: company_name})
+    existing_edge <- E<WorksAt>
+    edge <- existing_edge::UpsertE({position: position})::From(person)::To(company)
+    existing_resume <- V<Resume>::WHERE(_::{content}::EQ(resume_content))
+    resume <- existing_resume::UpsertV(Embed(resume_content), {content: resume_content})
+    RETURN person
+
+// Helper query to get persons
+QUERY GetPerson(name: String) =>
+    person <- N<Person>::WHERE(_::{name}::EQ(name))
+    RETURN person
+
+// Helper query to get all documents
+QUERY GetAllDocuments() =>
+    docs <- V<Document>
+    RETURN docs

--- a/hql-tests/tests/docs_upsert_v/schema.hx
+++ b/hql-tests/tests/docs_upsert_v/schema.hx
@@ -1,0 +1,26 @@
+// UpsertV documentation schema
+
+V::Document {
+    content: String,
+}
+
+N::Person {
+    INDEX name: String,
+    age: U32,
+}
+
+N::Company {
+    INDEX name: String,
+}
+
+V::Resume {
+    content: String,
+}
+
+E::WorksAt {
+    From: Person,
+    To: Company,
+    Properties: {
+        position: String,
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Version bumped `helix-cli` to 2.2.4 and `helix-db` to 1.2.4 to publish the changes from PR #815 which added relative paths to `helix.toml` validation errors. Also added three new test suites (`docs_upsert_e`, `docs_upsert_n`, `docs_upsert_v`) with comprehensive documentation examples for the UpsertE, UpsertN, and UpsertV operations.

- Version bumps are properly synchronized across `Cargo.toml` files and `Cargo.lock`
- New test suites follow existing naming conventions and structure (`docs_*` pattern)
- All test configurations use consistent port (6969) and build mode (dev)
- Test queries demonstrate key upsert patterns: WHERE filters, ID lookups, From/To ordering, and Embed function usage

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-cli/Cargo.toml | Version bumped from 2.2.3 to 2.2.4 |
| helix-db/Cargo.toml | Version bumped from 1.2.3 to 1.2.4 |
| Cargo.lock | Lock file updated to reflect version bumps in helix-cli (2.2.4) and helix-db (1.2.4) |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Cargo as Cargo.toml Files
    participant Lock as Cargo.lock
    participant Tests as Test Suite

    Dev->>Cargo: Bump helix-cli to 2.2.4
    Dev->>Cargo: Bump helix-db to 1.2.4
    Cargo->>Lock: Update dependency versions
    Dev->>Tests: Add docs_upsert_e test suite
    Dev->>Tests: Add docs_upsert_n test suite
    Dev->>Tests: Add docs_upsert_v test suite
    Tests-->>Dev: Documentation examples ready
    Lock-->>Dev: All versions synchronized
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->