### PR TITLE
impr (core): Fixing error status codes

### DIFF
--- a/helix-db/src/protocol/error.rs
+++ b/helix-db/src/protocol/error.rs
@@ -49,9 +49,21 @@ impl HelixError {
 impl IntoResponse for HelixError {
     fn into_response(self) -> axum::response::Response {
         let status = match &self {
-            HelixError::Graph(_) | HelixError::Vector(_) => 500,
-            HelixError::NotFound { .. } => 404,
-            HelixError::InvalidApiKey => 403,
+            HelixError::NotFound { .. }
+            | HelixError::Graph(
+                GraphError::ConfigFileNotFound
+                | GraphError::NodeNotFound
+                | GraphError::EdgeNotFound
+                | GraphError::LabelNotFound
+                | GraphError::ShortestPathNotFound,
+            )
+            | HelixError::Vector(VectorError::VectorNotFound(_)) => {
+                axum::http::StatusCode::NOT_FOUND
+            }
+            HelixError::Graph(_) | HelixError::Vector(_) => {
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR
+            }
+            HelixError::InvalidApiKey => axum::http::StatusCode::FORBIDDEN,
         };
 
         let error_response = ErrorResponse {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Improved HTTP status code precision by returning 404 for resource-not-found errors instead of generic 500 errors.

**Changes:**
- `GraphError::NodeNotFound`, `EdgeNotFound`, `ConfigFileNotFound`, `LabelNotFound`, `ShortestPathNotFound` now return 404
- `VectorError::VectorNotFound` now returns 404
- Other `GraphError` and `VectorError` variants continue to return 500
- Changed from integer literals to `axum::http::StatusCode` enum for better type safety

**Impact:**
- API clients can now distinguish between "resource not found" (404) and "server error" (500) for better error handling
- Aligns with REST API conventions where 404 indicates a missing resource
- Existing tests for 404/500 status codes still pass for their respective error types

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-db/src/protocol/error.rs | Improved HTTP status code mapping to return 404 for specific not-found errors (NodeNotFound, EdgeNotFound, VectorNotFound, etc.) instead of 500. Tests need to be added for the new 404 cases. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant AxumHandler
    participant HelixError
    participant ErrorResponse
    
    Client->>AxumHandler: HTTP Request
    AxumHandler->>AxumHandler: Process request
    
    alt Error occurs
        AxumHandler->>HelixError: Return error
        HelixError->>HelixError: Match error variant
        
        alt NotFound errors
            Note over HelixError: HelixError::NotFound<br/>GraphError::NodeNotFound<br/>GraphError::EdgeNotFound<br/>GraphError::ConfigFileNotFound<br/>GraphError::LabelNotFound<br/>GraphError::ShortestPathNotFound<br/>VectorError::VectorNotFound
            HelixError->>HelixError: status = 404 NOT_FOUND
        else InvalidApiKey
            Note over HelixError: HelixError::InvalidApiKey
            HelixError->>HelixError: status = 403 FORBIDDEN
        else Other errors
            Note over HelixError: Other GraphError<br/>Other VectorError
            HelixError->>HelixError: status = 500 INTERNAL_SERVER_ERROR
        end
        
        HelixError->>ErrorResponse: Create error response
        ErrorResponse->>ErrorResponse: Serialize to JSON
        ErrorResponse->>Client: HTTP Response with status code
    else Success
        AxumHandler->>Client: HTTP 200 OK
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->