### PR TITLE
fix(queries): fixing issue with nested non anonymous traversals using parent object as start

### DIFF
--- a/helix-db/src/helixc/analyzer/methods/query_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/query_validation.rs
@@ -359,7 +359,10 @@ fn build_return_fields(
                             .field_name_mappings
                             .values()
                             .any(|source_prop| source_prop == field_name);
-                        if already_exists || already_remapped {
+                        let already_covered_by_nested = traversal.nested_traversals.values().any(|info| {
+                            info.traversal.object_fields.iter().any(|f| f.to_lowercase() == field_name.to_lowercase())
+                        });
+                        if already_exists || already_remapped || already_covered_by_nested {
                             continue;
                         }
                         // Skip if excluded

--- a/helix-db/src/helixc/generator/queries.rs
+++ b/helix-db/src/helixc/generator/queries.rs
@@ -398,8 +398,9 @@ impl Query {
                                 let field_to_access = accessed_field.as_ref()
                                     .map(|s| s.as_str())
                                     .unwrap_or(field.name.as_str());
-                                // Use source_var for scope variables (project, workspace), fall back to singular_var for closure iteration vars (_, val)
-                                let access_var = if source_var == "_" || source_var == "val" { singular_var } else { source_var.as_str() };
+                                // Use singular_var (closure iteration variable) when source_var matches the collection variable,
+                                // or is a placeholder like _ or val. Use source_var directly only for scope variables (project, workspace).
+                                let access_var = if source_var == "_" || source_var == "val" || *source_var == struct_def.source_variable { singular_var } else { source_var.as_str() };
 
                                 if field_to_access == "id" || field_to_access == "ID" {
                                     format!("uuid_str({}.id(), &arena)", access_var)
@@ -762,8 +763,9 @@ impl Query {
                                 let field_to_access = accessed_field.as_ref()
                                     .map(|s| s.as_str())
                                     .unwrap_or(field.name.as_str());
-                                // Use source_var for scope variables (project, workspace), fall back to singular_var for closure iteration vars (_, val)
-                                let access_var = if source_var == "_" || source_var == "val" { singular_var } else { source_var.as_str() };
+                                // Use singular_var (closure iteration variable) when source_var matches the collection variable,
+                                // or is a placeholder like _ or val. Use source_var directly only for scope variables (project, workspace).
+                                let access_var = if source_var == "_" || source_var == "val" || *source_var == struct_def.source_variable { singular_var } else { source_var.as_str() };
 
                                 if field_to_access == "id" || field_to_access == "ID" {
                                     format!("uuid_str({}.id(), &arena)", access_var)
@@ -1237,8 +1239,9 @@ impl Query {
                                 let field_to_access = accessed_field.as_ref()
                                     .map(|s| s.as_str())
                                     .unwrap_or(field.name.as_str());
-                                // Use source_var for scope variables (project, workspace), fall back to singular_var for closure iteration vars (_, val)
-                                let access_var = if source_var == "_" || source_var == "val" { singular_var } else { source_var.as_str() };
+                                // Use singular_var (closure iteration variable) when source_var matches the collection variable,
+                                // or is a placeholder like _ or val. Use source_var directly only for scope variables (project, workspace).
+                                let access_var = if source_var == "_" || source_var == "val" || *source_var == struct_def.source_variable { singular_var } else { source_var.as_str() };
 
                                 if field_to_access == "id" || field_to_access == "ID" {
                                     format!("uuid_str({}.id(), &arena)", access_var)
@@ -1534,8 +1537,9 @@ impl Query {
                                 let field_to_access = accessed_field.as_ref()
                                     .map(|s| s.as_str())
                                     .unwrap_or(field.name.as_str());
-                                // Use source_var for scope variables (project, workspace), fall back to singular_var for closure iteration vars (_, val)
-                                let access_var = if source_var == "_" || source_var == "val" { singular_var } else { source_var.as_str() };
+                                // Use singular_var (closure iteration variable) when source_var matches the collection variable,
+                                // or is a placeholder like _ or val. Use source_var directly only for scope variables (project, workspace).
+                                let access_var = if source_var == "_" || source_var == "val" || *source_var == struct_def.source_variable { singular_var } else { source_var.as_str() };
 
                                 if field_to_access == "id" || field_to_access == "ID" {
                                     format!("uuid_str({}.id(), &arena)", access_var)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes variable resolution in nested non-anonymous traversals that use a parent object as their starting point. Previously, the code was always using `singular_var` (the iteration variable) for all nested traversal property access. Now it correctly uses `source_var` for scope variables (like `project`, `workspace`) while falling back to `singular_var` only for anonymous iteration variables (`_`, `val`).

**Key Changes:**
- Changed pattern match from `closure_source_var: Some(_)` to `Some(source_var)` to capture the actual variable name
- Added conditional logic: `if source_var == "_" || source_var == "val" { singular_var } else { source_var.as_str() }`
- Applied consistently across all 4 occurrences in the file (lines 402, 766, 1241, 1538)
- Updated comments to clarify the distinction between scope variables and closure iteration variables

**Impact:**
This fix ensures that queries like `project::{field}` correctly access the `project` variable rather than incorrectly using an iteration variable, enabling proper nested traversals that reference parent scope objects.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-db/src/helixc/generator/queries.rs | Updated variable access logic in nested traversals to correctly use source_var for scope variables (like project, workspace) while falling back to singular_var for iteration variables (_, val). The change is consistent across all four occurrences and follows the existing pattern used elsewhere in the codebase. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Query as Query Generator
    participant Pattern as Pattern Match
    participant Logic as Variable Resolution
    participant Output as Generated Code

    Query->>Pattern: Match NestedTraversal with closure_source_var
    Pattern->>Pattern: Extract source_var from closure_source_var
    Pattern->>Logic: Determine access_var
    
    alt source_var is "_" or "val" (iteration variable)
        Logic->>Logic: Use singular_var (e.g., "e" from entries::|e|)
    else source_var is scope variable (e.g., "project", "workspace")
        Logic->>Logic: Use source_var as-is
    end
    
    Logic->>Output: Generate property access code
    
    alt field is "id" or "ID"
        Output->>Output: uuid_str(access_var.id(), &arena)
    else field is "label" or "Label"
        Output->>Output: access_var.label()
    else field is custom property
        Output->>Output: access_var.get_property("field_name")
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->