### PR TITLE
impr(core+hql): implementing ordered return values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,7 @@ dependencies = [
  "heed3",
  "helix-macros",
  "helix-metrics",
+ "indexmap",
  "inventory",
  "itertools 0.14.0",
  "lazy_static",

--- a/helix-db/Cargo.toml
+++ b/helix-db/Cargo.toml
@@ -34,6 +34,7 @@ rayon = "1.11.0"
 mimalloc = "0.1.48"
 bumpalo = { version = "3.19.0", features = ["collections", "boxed", "serde"] }
 bytemuck = "1.24.0"
+indexmap = { version = "2.7", features = ["serde"] }
 
 # compiler dependencies
 pest = { version = "2.7", optional = true }

--- a/helix-db/src/helixc/analyzer/methods/exclude_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/exclude_validation.rs
@@ -11,6 +11,7 @@ use crate::{
         parser::{location::Loc, types::*},
     },
 };
+use indexmap::IndexMap;
 use paste::paste;
 use std::{borrow::Cow, collections::HashMap};
 
@@ -29,7 +30,7 @@ use std::{borrow::Cow, collections::HashMap};
 pub(crate) fn validate_exclude_fields<'a>(
     ctx: &mut Ctx<'a>,
     ex: &Exclude,
-    field_set: &HashMap<&str, Cow<'a, Field>>,
+    field_set: &IndexMap<&str, Cow<'a, Field>>,
     excluded: &HashMap<&str, Loc>,
     original_query: &'a Query,
     type_name: &str,

--- a/helix-db/src/helixc/analyzer/methods/object_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/object_validation.rs
@@ -24,8 +24,9 @@ use crate::{
         parser::types::*,
     },
 };
+use indexmap::IndexMap;
 use paste::paste;
-use std::{borrow::Cow, collections::HashMap};
+use std::borrow::Cow;
 
 /// Marks all Out/In steps with EdgeType::Vec in the traversal to fetch vector data
 /// This should be called when the 'data' field is accessed on a Vector type
@@ -217,7 +218,7 @@ fn validate_property_access<'a>(
     original_query: &'a Query,
     gen_traversal: &mut GeneratedTraversal,
     cur_ty: &Type,
-    fields: Option<HashMap<&'a str, Cow<'a, Field>>>,
+    fields: Option<IndexMap<&'a str, Cow<'a, Field>>>,
     fields_out: &mut Vec<ReturnValueField>,
     scope: &mut std::collections::HashMap<&'a str, crate::helixc::analyzer::utils::VariableInfo>,
     gen_query: &mut crate::helixc::generator::queries::Query,

--- a/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
@@ -37,6 +37,7 @@ use crate::{
     },
     protocol::value::Value,
 };
+use indexmap::IndexMap;
 use paste::paste;
 use std::collections::HashMap;
 
@@ -191,7 +192,7 @@ pub(crate) fn validate_traversal<'a>(
                                             E201,
                                             node_type
                                         );
-                                        HashMap::default()
+                                        IndexMap::default()
                                     });
 
                                 match corresponding_field

--- a/helix-db/src/helixc/analyzer/mod.rs
+++ b/helix-db/src/helixc/analyzer/mod.rs
@@ -25,6 +25,7 @@ use crate::{
         },
     },
 };
+use indexmap::IndexMap;
 use itertools::Itertools;
 use serde::Serialize;
 use std::{
@@ -56,9 +57,9 @@ pub(crate) struct Ctx<'a> {
     pub(super) node_set: HashSet<&'a str>,
     pub(super) vector_set: HashSet<&'a str>,
     pub(super) edge_map: HashMap<&'a str, &'a EdgeSchema>,
-    pub(super) node_fields: HashMap<&'a str, HashMap<&'a str, Cow<'a, Field>>>,
-    pub(super) edge_fields: HashMap<&'a str, HashMap<&'a str, Cow<'a, Field>>>,
-    pub(super) vector_fields: HashMap<&'a str, HashMap<&'a str, Cow<'a, Field>>>,
+    pub(super) node_fields: IndexMap<&'a str, IndexMap<&'a str, Cow<'a, Field>>>,
+    pub(super) edge_fields: IndexMap<&'a str, IndexMap<&'a str, Cow<'a, Field>>>,
+    pub(super) vector_fields: IndexMap<&'a str, IndexMap<&'a str, Cow<'a, Field>>>,
     pub(super) all_schemas: SchemaVersionMap<'a>,
     pub(super) diagnostics: Vec<Diagnostic>,
     pub(super) output: GeneratedSource,
@@ -126,7 +127,7 @@ impl<'a> Ctx<'a> {
     pub(super) fn get_item_fields(
         &self,
         item_type: &Type,
-    ) -> Option<&HashMap<&str, Cow<'_, Field>>> {
+    ) -> Option<&IndexMap<&str, Cow<'_, Field>>> {
         match item_type {
             Type::Node(Some(node_type)) | Type::Nodes(Some(node_type)) => {
                 self.node_fields.get(node_type.as_str())
@@ -206,7 +207,7 @@ pub struct NodeData {
 }
 
 impl NodeData {
-    fn from_entry(val: (&&str, &HashMap<&str, Cow<Field>>)) -> Self {
+    fn from_entry(val: (&&str, &IndexMap<&str, Cow<Field>>)) -> Self {
         let properties = val
             .1
             .iter()


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements ordered return values for HelixQL query results by replacing `HashMap` with `IndexMap` throughout the field lookup system. This change ensures that fields are returned in a deterministic, consistent order.

**Key Changes:**
- Replaced all `HashMap<&str, Cow<Field>>` with `IndexMap<&str, Cow<Field>>` for field lookups
- Ensured built-in fields (`id`, `label`, `data`, `score`, `from_node`, `to_node`) are inserted first, followed by user-defined fields in schema definition order
- Added `indexmap` v2.7 dependency with serde support
- Updated all dependent code paths to use `IndexMap` consistently

**Impact:**
The change provides deterministic field ordering in query results, which improves API consistency and makes the behavior more predictable for users. Built-in fields will always appear first, followed by custom fields in the order they were defined in the schema.

The implementation is clean, comprehensive, and maintains backward compatibility while adding the ordering guarantee.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-db/Cargo.toml | Added `indexmap` v2.7 with serde features to support ordered field lookups |
| helix-db/src/helixc/analyzer/methods/schema_methods.rs | Replaced HashMap with IndexMap for field lookups and ensured built-in fields (id, label, etc.) are inserted before user-defined fields to maintain consistent ordering |
| helix-db/src/helixc/analyzer/mod.rs | Updated field lookup types from HashMap to IndexMap in Ctx struct and NodeData::from_entry signature |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Parser as HelixQL Parser
    participant Analyzer as Analyzer::Ctx
    participant SchemaBuilder as build_field_lookups
    participant IndexMap as IndexMap<Field>
    participant IntrospectionData as IntrospectionData
    
    Parser->>Analyzer: analyze(Source)
    Analyzer->>SchemaBuilder: build_field_lookups(src)
    
    Note over SchemaBuilder,IndexMap: For each schema version
    
    SchemaBuilder->>IndexMap: Create IndexMap for nodes
    Note over IndexMap: Insert built-in fields first:<br/>1. id (Uuid)<br/>2. label (String)
    SchemaBuilder->>IndexMap: Insert user-defined fields in order
    
    SchemaBuilder->>IndexMap: Create IndexMap for edges
    Note over IndexMap: Insert built-in fields first:<br/>1. id, 2. label<br/>3. from_node, 4. to_node
    SchemaBuilder->>IndexMap: Insert edge properties in order
    
    SchemaBuilder->>IndexMap: Create IndexMap for vectors
    Note over IndexMap: Insert built-in fields first:<br/>1. id, 2. label<br/>3. data, 4. score
    SchemaBuilder->>IndexMap: Insert vector fields in order
    
    SchemaBuilder-->>Analyzer: Return SchemaVersionMap<IndexMap>
    
    Analyzer->>IntrospectionData: from_schema(ctx)
    Note over IntrospectionData: Fields now maintain<br/>insertion order
    IntrospectionData-->>Analyzer: Ordered field metadata
    
    Analyzer-->>Parser: Return (diagnostics, ordered fields)
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->