### PR TITLE
fix(hql): property access causing codegen failure

### DIFF
--- a/helix-db/src/helixc/generator/traversal_steps.rs
+++ b/helix-db/src/helixc/generator/traversal_steps.rs
@@ -833,6 +833,108 @@ impl Display for WhereRef {
                     );
                 }
             }
+
+            // Handle traversals with prefix steps before property access + BoolOp
+            // Pattern: [traversal steps...] + [PropertyFetch or ReservedPropertyAccess] + BoolOp
+            if is_val && traversal.steps.len() > 2 {
+                let last_idx = traversal.steps.len() - 1;
+                let second_last_idx = traversal.steps.len() - 2;
+
+                let last_step = traversal.steps[last_idx].inner();
+                let second_last_step = traversal.steps[second_last_idx].inner();
+
+                // Check if pattern matches: [...] + PropertyAccess + BoolOp
+                if let Step::BoolOp(bool_op) = last_step {
+                    // Build the prefix traversal steps (all steps except the last 2)
+                    let prefix_steps = &traversal.steps[..second_last_idx];
+
+                    // Generate the traversal chain for prefix steps
+                    let traversal_chain = prefix_steps
+                        .iter()
+                        .map(|sep| format!("{}", sep))
+                        .collect::<Vec<_>>()
+                        .join("");
+
+                    match second_last_step {
+                        // Case 1: PropertyFetch (e.g., _::ToN::{age}::EQ(id))
+                        Step::PropertyFetch(prop) => {
+                            let bool_expr = match bool_op {
+                                BoolOp::Eq(eq) => format!("{eq}"),
+                                BoolOp::Neq(neq) => format!("{neq}"),
+                                BoolOp::Gt(gt) => format!("{gt}"),
+                                BoolOp::Gte(gte) => format!("{gte}"),
+                                BoolOp::Lt(lt) => format!("{lt}"),
+                                BoolOp::Lte(lte) => format!("{lte}"),
+                                BoolOp::Contains(c) => format!("v{c}"),
+                                BoolOp::IsIn(i) => format!("v{i}"),
+                                BoolOp::PropertyEq(p) => format!("{p}"),
+                                BoolOp::PropertyNeq(p) => format!("{p}"),
+                            };
+
+                            return write!(
+                                f,
+                                "filter_ref(|val, txn|{{
+                if let Ok(val) = val {{
+                    Ok(G::from_iter(&db, &txn, std::iter::once(val.clone()), &arena)
+                        {}
+                        .next()
+                        .map_or(false, |res| {{
+                            res.map_or(false, |node| {{
+                                node.get_property({}).map_or(false, |v| {})
+                            }})
+                        }}))
+                }} else {{
+                    Ok(false)
+                }}
+            }})",
+                                traversal_chain, prop, bool_expr
+                            );
+                        }
+
+                        // Case 2: ReservedPropertyAccess (e.g., _::ToN::ID::EQ(id))
+                        Step::ReservedPropertyAccess(reserved_prop) => {
+                            let value_expr = match reserved_prop {
+                                ReservedProp::Id => "Value::Id(ID::from(node.id()))".to_string(),
+                                ReservedProp::Label => "Value::from(node.label())".to_string(),
+                            };
+                            let bool_expr = match bool_op {
+                                BoolOp::Eq(eq) => format!("{} == {}", value_expr, eq.right),
+                                BoolOp::Neq(neq) => format!("{} != {}", value_expr, neq.right),
+                                BoolOp::Gt(gt) => format!("{} > {}", value_expr, gt.right),
+                                BoolOp::Gte(gte) => format!("{} >= {}", value_expr, gte.right),
+                                BoolOp::Lt(lt) => format!("{} < {}", value_expr, lt.right),
+                                BoolOp::Lte(lte) => format!("{} <= {}", value_expr, lte.right),
+                                BoolOp::Contains(c) => format!("{}{}", value_expr, c),
+                                BoolOp::IsIn(i) => format!("{}{}", value_expr, i),
+                                BoolOp::PropertyEq(_) | BoolOp::PropertyNeq(_) => {
+                                    "compile_error!(\"PropertyEq/PropertyNeq cannot be used with reserved properties\")".to_string()
+                                }
+                            };
+
+                            return write!(
+                                f,
+                                "filter_ref(|val, txn|{{
+                if let Ok(val) = val {{
+                    Ok(G::from_iter(&db, &txn, std::iter::once(val.clone()), &arena)
+                        {}
+                        .next()
+                        .map_or(false, |res| {{
+                            res.map_or(false, |node| {{
+                                {}
+                            }})
+                        }}))
+                }} else {{
+                    Ok(false)
+                }}
+            }})",
+                                traversal_chain, bool_expr
+                            );
+                        }
+
+                        _ => {} // Fall through to default
+                    }
+                }
+            }
         }
 
         // Fall back to default (unoptimized) code generation

--- a/hql-tests/tests/where_traversal_property_access/helix.toml
+++ b/hql-tests/tests/where_traversal_property_access/helix.toml
@@ -1,0 +1,9 @@
+[project]
+name = "where_traversal_property_access"
+queries = "."
+
+[local.dev]
+port = 6969
+build_mode = "dev"
+
+[cloud]

--- a/hql-tests/tests/where_traversal_property_access/queries.hx
+++ b/hql-tests/tests/where_traversal_property_access/queries.hx
@@ -1,0 +1,38 @@
+// Test cases for GitHub issue #847
+// WHERE clauses with traversal steps before property access
+
+// Test 1: ReservedPropertyAccess with ToN (original issue case)
+// Pattern: _::ToN::ID::EQ(id)
+QUERY testToNId(id: ID) =>
+    edges <- N<Person>::OutE<Knows>::WHERE(_::ToN::ID::EQ(id))
+    RETURN edges
+
+// Test 2: ReservedPropertyAccess with FromN
+// Pattern: _::FromN::ID::EQ(id)
+QUERY testFromNId(id: ID) =>
+    edges <- N<Person>::OutE<Knows>::WHERE(_::FromN::ID::EQ(id))
+    RETURN edges
+
+// Test 3: PropertyFetch with ToN (original issue case)
+// Pattern: _::ToN::{age}::EQ(age)
+QUERY testToNProperty(age: I32) =>
+    edges <- N<Person>::OutE<Knows>::WHERE(_::ToN::{age}::EQ(age))
+    RETURN edges
+
+// Test 4: PropertyFetch with FromN
+// Pattern: _::FromN::{name}::EQ(name)
+QUERY testFromNProperty(name: String) =>
+    edges <- N<Person>::OutE<Knows>::WHERE(_::FromN::{name}::EQ(name))
+    RETURN edges
+
+// Test 5: Simple 2-step case (should still work - regression test)
+// Pattern: _::ID::EQ(id)
+QUERY testSimpleId(id: ID) =>
+    nodes <- N<Person>::WHERE(_::ID::EQ(id))
+    RETURN nodes
+
+// Test 6: Simple 2-step property fetch (should still work - regression test)
+// Pattern: _{age}::EQ(age)
+QUERY testSimpleProperty(age: I32) =>
+    nodes <- N<Person>::WHERE(_::{age}::EQ(age))
+    RETURN nodes

--- a/hql-tests/tests/where_traversal_property_access/schema.hx
+++ b/hql-tests/tests/where_traversal_property_access/schema.hx
@@ -1,0 +1,12 @@
+N::Person {
+    name: String,
+    age: I32
+}
+
+E::Knows {
+    From: Person,
+    To: Person,
+    Properties: {
+        since: I32
+    }
+}


### PR DESCRIPTION
Fixes #847

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes Rust codegen failure for WHERE clauses with multi-step traversals before property access (e.g., `_::ToN::ID::EQ(id)`).

The existing code generation only handled 2-step patterns (property access + boolean operation), causing compilation failures when traversal steps like `ToN` or `FromN` preceded property access. This PR extends the pattern matching to handle 3+ step traversals by:

- Detecting patterns with traversal prefix steps before property access and boolean operations
- Generating `filter_ref` closures that use `G::from_iter` to execute the traversal chain before property evaluation
- Supporting both `ReservedPropertyAccess` (ID, Label) and `PropertyFetch` (custom properties)
- Preserving backwards compatibility with existing 2-step patterns through explicit length checks

The fix includes comprehensive test coverage for `ToN`, `FromN` traversals with various property types and regression tests for simple cases.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-db/src/helixc/generator/traversal_steps.rs | Added code generation support for multi-step traversal patterns with property access (e.g., `_::ToN::ID::EQ(id)`), extending existing 2-step pattern handling to 3+ steps |
| hql-tests/tests/where_traversal_property_access/queries.hx | Comprehensive test coverage for the fix including `ToN`, `FromN` traversals with both reserved properties (ID) and custom properties, plus regression tests |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant HQL as HQL Query Parser
    participant TGen as Traversal Code Generator
    participant WhereRef as WhereRef Display
    participant RustCode as Generated Rust Code
    
    Note over HQL,RustCode: Example: WHERE(_::ToN::ID::EQ(id))
    
    HQL->>TGen: Parse traversal steps<br/>[_, ToN, ID, EQ(id)]
    TGen->>WhereRef: Display WhereRef with traversal
    
    alt 2-step pattern (existing)
        Note over WhereRef: Pattern: _::ID::EQ(id)
        WhereRef->>WhereRef: Check traversal.steps.len() == 2
        WhereRef->>WhereRef: Extract ReservedPropertyAccess + BoolOp
        WhereRef->>RustCode: Generate filter_ref with direct val access
    else 3+ step pattern (NEW FIX)
        Note over WhereRef: Pattern: _::ToN::ID::EQ(id)
        WhereRef->>WhereRef: Check traversal.steps.len() > 2
        WhereRef->>WhereRef: Extract last step (BoolOp)
        WhereRef->>WhereRef: Extract second-last step (PropertyAccess/ReservedProp)
        WhereRef->>WhereRef: Extract prefix steps ([_, ToN])
        alt ReservedPropertyAccess (ID/Label)
            WhereRef->>RustCode: Generate filter_ref with:<br/>1. G::from_iter for traversal<br/>2. node.id()/label() access<br/>3. Boolean comparison
        else PropertyFetch ({property})
            WhereRef->>RustCode: Generate filter_ref with:<br/>1. G::from_iter for traversal<br/>2. node.get_property() access<br/>3. Boolean expression
        end
    else Fallback
        WhereRef->>RustCode: Generate unoptimized filter_ref
    end
    
    RustCode->>RustCode: Compile generated Rust code
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->