### PR TITLE
fix(cli) Fixing helix push

### DIFF
--- a/helix-cli/src/commands/push.rs
+++ b/helix-cli/src/commands/push.rs
@@ -174,7 +174,7 @@ async fn push_local_instance(
             ("Local URL", &format!("http://localhost:{actual_port}")),
             (
                 "Container",
-                &format!("helix_{project_name}_{instance_name}"),
+                &format!("helix-{project_name}-{instance_name}"),
             ),
             (
                 "Data volume",

--- a/helix-cli/src/docker.rs
+++ b/helix-cli/src/docker.rs
@@ -707,11 +707,11 @@ networks:
     /// Check if an instance container exists (running or stopped)
     pub fn instance_exists(&self, instance_name: &str) -> Result<bool> {
         let statuses = self.get_project_status()?;
-        let target_container_name = format!("helix_{instance_name}_app");
+        let target_container_name = self.container_name(instance_name);
 
         Ok(statuses
             .iter()
-            .any(|status| status.container_name.contains(&target_container_name)))
+            .any(|status| status.container_name == target_container_name))
     }
 
     /// Get status of all Docker/Podman containers for this project


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed container name display format and improved container existence checking in the CLI, and resolved HQL codegen failure for WHERE clauses with traversal steps before property access.

## Key Changes

- **CLI Container Naming**: Updated display format from `helix_{project}_{instance}` to `helix-{project}-{instance}` to match actual Docker container naming convention (hyphens instead of underscores)
- **Container Check Improvement**: Refactored `instance_exists` to use centralized `container_name` method and exact string matching instead of `contains`, improving accuracy
- **HQL Codegen Fix (#847)**: Added support for WHERE clauses with multi-step traversal patterns like `_::ToN::ID::EQ(id)` and `_::ToN::{age}::EQ(age)` that previously caused Rust codegen failures
- **Test Coverage**: Added comprehensive test suite for the new traversal property access patterns with 6 test queries covering various edge cases

The changes are well-structured and include proper test coverage for the codegen fix.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-cli/src/commands/push.rs | Fixed container name display format from underscores to hyphens to match actual naming scheme |
| helix-cli/src/docker.rs | Improved container existence check to use centralized container_name method and exact match instead of contains |
| helix-db/src/helixc/generator/traversal_steps.rs | Added codegen support for WHERE clauses with traversal steps before property access (fixes #847) |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as Helix CLI
    participant Docker as Docker/Podman
    participant Compiler as HelixC Codegen
    
    Note over User,Compiler: CLI Container Naming Fix
    User->>CLI: helix push
    CLI->>CLI: compose_project_name(instance_name)
    Note right of CLI: Returns "helix-{project}-{instance}"
    CLI->>CLI: container_name(instance_name)
    Note right of CLI: Returns "helix-{project}-{instance}_app"
    CLI->>Docker: Check container exists
    Docker-->>CLI: Container status
    CLI->>CLI: Display container info
    Note right of CLI: Now shows "helix-{project}-{instance}" (fixed from "helix_{project}_{instance}")
    
    Note over User,Compiler: HQL Traversal Property Access Fix (#847)
    User->>Compiler: Compile WHERE(_::ToN::ID::EQ(id))
    Compiler->>Compiler: Parse traversal steps
    Note right of Compiler: Detects pattern: [ToN] + [ID] + [EQ]
    Compiler->>Compiler: Generate optimized filter_ref
    Note right of Compiler: Creates traversal chain + property access
    Compiler-->>User: Valid Rust code generated
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->