### PR TITLE
fix(hql): Fixing count type checking

### DIFF
--- a/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
+++ b/helix-db/src/helixc/analyzer/methods/traversal_validation.rs
@@ -885,6 +885,7 @@ pub(crate) fn validate_traversal<'a>(
                         ) {
                             (Type::Scalar(ft), _) => ft.clone(),
                             (Type::Boolean, _) => FieldType::Boolean,
+                            (Type::Count, _) => FieldType::I64,
                             (field_type, _) => {
                                 generate_error!(
                                     ctx,


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed type checking for `Count` type in boolean expressions and added code generation support for WHERE clauses with multi-step traversals before property access (fixes #847).

**Key Changes:**
- **Type Analyzer**: Added `Type::Count` case mapping to `FieldType::I64` in `traversal_validation.rs:888`
- **Code Generator**: Implemented pattern matching for traversals with 3+ steps ending in PropertyFetch/ReservedPropertyAccess + BoolOp in `traversal_steps.rs:837-937`
- **Test Coverage**: Added comprehensive test suite covering `ToN`/`FromN` with `ID` access and property fetches

**Implementation Details:**
The new codegen handles patterns like `_::ToN::ID::EQ(id)` by:
1. Extracting prefix traversal steps (e.g., `_::ToN`)
2. Generating `G::from_iter` to execute the traversal chain
3. Applying property access and boolean comparison on the resulting node

The code properly handles both reserved properties (`ID`, `Label`) and user-defined properties with appropriate getter methods.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-db/src/helixc/analyzer/methods/traversal_validation.rs | Added `Type::Count` case to map to `FieldType::I64` in boolean expression type checking |
| helix-db/src/helixc/generator/traversal_steps.rs | Added code generation for WHERE clauses with traversal steps before property access (fixes issue #847) |
| hql-tests/tests/where_traversal_property_access/queries.hx | New test queries covering traversal property access patterns including `ToN`, `FromN` with `ID` and property fetches |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as Query Code
    participant Parser as HQL Parser
    participant Analyzer as Type Analyzer
    participant Generator as Code Generator
    participant Runtime as Generated Rust Code

    User->>Parser: Parse WHERE clause with traversal
    Note over Parser: WHERE(_::ToN::ID::EQ(id))
    Parser->>Analyzer: Validate traversal steps
    
    alt Type::Count in boolean expression
        Analyzer->>Analyzer: Check expression type
        Note over Analyzer: (Type::Count, _) => FieldType::I64
        Analyzer->>Generator: Type validated as I64
    else Type::Boolean in boolean expression
        Analyzer->>Analyzer: Map to FieldType::Boolean
        Analyzer->>Generator: Type validated as Boolean
    else Type::Scalar in boolean expression
        Analyzer->>Analyzer: Use existing FieldType
        Analyzer->>Generator: Type validated
    end

    Generator->>Generator: Check pattern: steps > 2?
    alt Pattern: [...] + PropertyAccess + BoolOp
        Generator->>Generator: Extract prefix steps
        Generator->>Generator: Build traversal chain
        
        alt Case: ReservedPropertyAccess (ID/Label)
            Generator->>Runtime: Generate filter_ref with G::from_iter
            Note over Runtime: Access node.id() or node.label()
        else Case: PropertyFetch
            Generator->>Runtime: Generate filter_ref with get_property
            Note over Runtime: Access node.get_property(name)
        end
    else Simple 2-step pattern
        Generator->>Runtime: Use optimized short path
    end

    Runtime->>User: Return filtered results
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->