### PR TITLE
fix(core): date parsing ordering violation

### DIFF
--- a/helix-db/src/protocol/value.rs
+++ b/helix-db/src/protocol/value.rs
@@ -2748,12 +2748,21 @@ mod tests {
 
     #[test]
     fn test_value_ordering_mixed_types() {
-        // Non-comparable types should return Equal
-        assert_eq!(
-            Value::String("test".to_string()).cmp(&Value::I32(42)),
-            Ordering::Equal
-        );
-        assert_eq!(Value::Boolean(true).cmp(&Value::F64(3.14)), Ordering::Equal);
+        // Non-comparable types should return a consistent ordering based on variant
+        // discriminant, not Equal (which would violate the Ord contract since
+        // PartialEq returns false for these pairs).
+        let s = Value::String("test".to_string());
+        let i = Value::I32(42);
+        let b = Value::Boolean(true);
+        let f = Value::F64(3.14);
+
+        // Ordering must be consistent (antisymmetric)
+        assert_eq!(s.cmp(&i), i.cmp(&s).reverse());
+        assert_eq!(b.cmp(&f), f.cmp(&b).reverse());
+
+        // Ordering must not be Equal for different variant types
+        assert_ne!(s.cmp(&i), Ordering::Equal);
+        assert_ne!(b.cmp(&f), Ordering::Equal);
     }
 
     #[test]


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed a critical Ord trait violation in the `Value` enum's comparison implementation. Previously, incomparable types (e.g., `Date` vs non-parseable `String`, or mismatched variants) returned `Ordering::Equal`, which violates Rust's Ord contract since `a.cmp(b) == Equal` should only occur when `a == b`.

**Changes:**
- Added `variant_order()` helper method that assigns a deterministic u8 ordering value to each Value variant
- Replaced `Ordering::Equal` fallback cases with `self.variant_order().cmp(&other.variant_order())`
- Ensures total ordering across all Value types, preventing potential undefined behavior in sorting algorithms and data structures

**Impact:**
This fix prevents subtle bugs in any code that relies on sorting or ordering Value types, particularly when dealing with heterogeneous data.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-db/src/protocol/value.rs | Fixed Ord trait violation by using variant ordering instead of Equal for incomparable types. Added variant_order() helper method for consistent type ordering. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Value_Ord
    participant variant_order
    
    Caller->>Value_Ord: cmp(self, other)
    
    alt Same type comparison
        Value_Ord->>Value_Ord: Direct comparison (String, Date, etc.)
        Value_Ord-->>Caller: Ordering result
    else Integer types
        Value_Ord->>Value_Ord: Convert to i128 and compare
        Value_Ord-->>Caller: Ordering result
    else Date ↔ String
        Value_Ord->>Value_Ord: Try parse String as Date
        alt Parse successful
            Value_Ord->>Value_Ord: Compare dates
            Value_Ord-->>Caller: Ordering result
        else Parse failed (NEW)
            Value_Ord->>variant_order: Get variant order for self
            Value_Ord->>variant_order: Get variant order for other
            variant_order-->>Value_Ord: u8 ordering values
            Value_Ord->>Value_Ord: Compare u8 values
            Value_Ord-->>Caller: Deterministic ordering
        end
    else Incomparable types (NEW)
        Value_Ord->>variant_order: Get variant order for self
        Value_Ord->>variant_order: Get variant order for other
        variant_order-->>Value_Ord: u8 ordering values
        Value_Ord->>Value_Ord: Compare u8 values
        Value_Ord-->>Caller: Deterministic ordering
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->