### PR TITLE
fix(core): date deserialisation fix

### DIFF
--- a/helix-db/src/helix_engine/storage_core/storage_migration_tests.rs
+++ b/helix-db/src/helix_engine/storage_core/storage_migration_tests.rs
@@ -9,12 +9,12 @@
 //! - Performance tests for large datasets
 
 use super::{
-    HelixGraphStorage,
-    metadata::{NATIVE_VECTOR_ENDIANNESS, StorageMetadata, VectorEndianness},
+    metadata::{StorageMetadata, VectorEndianness, NATIVE_VECTOR_ENDIANNESS},
     storage_migration::{
         convert_all_vector_properties, convert_old_vector_properties_to_new_format,
         convert_vector_endianness, migrate,
     },
+    HelixGraphStorage,
 };
 use crate::{
     helix_engine::{
@@ -889,7 +889,6 @@ fn test_error_corrupted_property_data() {
 }
 
 #[test]
-#[ignore]
 fn test_date_bincode_serialization() {
     // Test that Date values serialize/deserialize correctly with bincode
     use crate::protocol::date::Date;
@@ -901,7 +900,7 @@ fn test_date_bincode_serialization() {
     // Serialize with bincode
     let serialized = bincode::serialize(&value).unwrap();
     println!("\nValue::Date serialized to {} bytes", serialized.len());
-    println!("Format: [variant=12] [i64 timestamp]");
+    println!("Format: [variant=12] [RFC3339 string]");
     println!("Bytes: {:?}", serialized);
 
     // Deserialize

--- a/helix-db/src/protocol/value.rs
+++ b/helix-db/src/protocol/value.rs
@@ -2900,6 +2900,7 @@ mod tests {
             Value::F64(3.14),
             Value::Boolean(true),
             Value::U128(u128::MAX),
+            Value::Date(Date::new(&Value::String("2021-01-01T00:00:00Z".to_string())).unwrap()),
             Value::Empty,
             Value::Array(vec![Value::I32(1), Value::I32(2)]),
         ];


### PR DESCRIPTION
Fixes #872 

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed date deserialization bug where bincode (non-human-readable format) was incorrectly using the generic visitor path instead of properly deserializing RFC3339 strings.

**Key Changes:**
- Modified `Date::deserialize()` to check `is_human_readable()` and route bincode through string deserialization path
- Re-enabled previously ignored test `test_date_bincode_serialization` now that the bug is resolved
- Added comprehensive test coverage across nodes, edges, vectors, and traversal operations with date properties
- Updated test comments to reflect RFC3339 serialization format

The fix ensures that when bincode serializes dates as RFC3339 strings (via the `Serialize` impl), the `Deserialize` impl properly handles this by parsing the string back to a `DateTime<Utc>` for non-human-readable deserializers.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-db/src/protocol/date.rs | Fixed bincode deserialization by checking `is_human_readable()` to route non-human-readable formats (like bincode) to string deserialization path, added test coverage |
| helix-db/src/protocol/value.rs | Added `Value::Date` case to bincode roundtrip test for completeness |
| helix-db/src/helix_engine/storage_core/storage_migration_tests.rs | Removed `#[ignore]` from date bincode test now that the issue is fixed, updated comment to reflect RFC3339 serialization format |
| helix-db/src/protocol/custom_serde/integration_tests.rs | Added comprehensive bincode roundtrip tests for nodes, edges, and vectors with date properties |

</details>


</details>


<sub>Last reviewed commit: f40cc7b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->