### PR TITLE
fix overwriting gitignore in initializaiton

### DIFF
--- a/helix-cli/src/commands/init.rs
+++ b/helix-cli/src/commands/init.rs
@@ -351,12 +351,8 @@ target/
         .append(true)
         .open(&gitignore_path)?;
     for line in gitignore.lines() {
-    for line in gitignore.lines() {
         let trimmed = line.trim();
         if !existing.lines().any(|l| l.trim() == trimmed) {
-            writeln!(file, "{}", line)?;
-        }
-    }
             writeln!(file, "{}", line)?;
         }
     }


### PR DESCRIPTION
## Description
when we initialization helix with `helix init` in a folder that contains a .gitignore with some content that got wriped and overwritten. this PR fixes that 
## Related Issues
Closes #876 

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `.gitignore` handling from overwrite to append mode to preserve existing content when running `helix init`.

- Reads existing `.gitignore` content before adding new entries
- Only appends lines that don't already exist
- Fixes issue #876 where existing `.gitignore` was being wiped

**Issue found**: The duplicate check uses substring matching (`existing.contains(line)`) which can cause false positives - e.g., if `.gitignore` contains `my-target/`, the check for `target/` will incorrectly skip adding it.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-cli/src/commands/init.rs | Fixed gitignore overwriting, but substring matching logic has edge case bugs |

</details>


</details>


<sub>Last reviewed commit: 3e51c60</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->