### PR TITLE
[Bug]: UpsertN ignores and overwrites default values.

### DIFF
--- a/helix-db/src/helixc/generator/traversal_steps.rs
+++ b/helix-db/src/helixc/generator/traversal_steps.rs
@@ -51,6 +51,7 @@ pub enum TraversalType {
         source_is_plural: bool,
         label: String,
         properties: Option<Vec<(String, GeneratedValue)>>,
+        create_defaults: Option<Vec<(String, GeneratedValue)>>,
     },
     /// UpsertE - upsert for edges with From/To connection
     UpsertE {
@@ -58,6 +59,7 @@ pub enum TraversalType {
         source_is_plural: bool,
         label: String,
         properties: Option<Vec<(String, GeneratedValue)>>,
+        create_defaults: Option<Vec<(String, GeneratedValue)>>,
         from: GeneratedValue,
         to: GeneratedValue,
     },
@@ -67,6 +69,7 @@ pub enum TraversalType {
         source_is_plural: bool,
         label: String,
         properties: Option<Vec<(String, GeneratedValue)>>,
+        create_defaults: Option<Vec<(String, GeneratedValue)>>,
         vec_data: Option<VecData>,
     },
     /// Standalone - no G::new wrapper, just the source step (used for plural AddE)
@@ -250,6 +253,7 @@ impl Display for Traversal {
                 source_is_plural,
                 label,
                 properties,
+                create_defaults,
             } => {
                 match source {
                     Some(var) => {
@@ -281,9 +285,10 @@ impl Display for Traversal {
                 }
                 write!(
                     f,
-                    "\n    .upsert_n(\"{}\", {})",
+                    "\n    .upsert_n_with_defaults(\"{}\", {}, {})",
                     label,
-                    write_properties_slice(properties)
+                    write_properties_slice(properties),
+                    write_properties_slice(create_defaults)
                 )?;
                 write!(f, "\n    .collect_to_obj()?")?;
                 if source.is_none() {
@@ -295,6 +300,7 @@ impl Display for Traversal {
                 source_is_plural,
                 label,
                 properties,
+                create_defaults,
                 from,
                 to,
             } => {
@@ -328,11 +334,12 @@ impl Display for Traversal {
                 }
                 write!(
                     f,
-                    "\n    .upsert_e(\"{}\", {}.id(), {}.id(), {})",
+                    "\n    .upsert_e_with_defaults(\"{}\", {}.id(), {}.id(), {}, {})",
                     label,
                     from,
                     to,
-                    write_properties_slice(properties)
+                    write_properties_slice(properties),
+                    write_properties_slice(create_defaults)
                 )?;
                 write!(f, "\n    .collect_to_obj()?")?;
                 if source.is_none() {
@@ -344,6 +351,7 @@ impl Display for Traversal {
                 source_is_plural,
                 label,
                 properties,
+                create_defaults,
                 vec_data,
             } => {
                 match source {
@@ -378,18 +386,20 @@ impl Display for Traversal {
                     Some(vd) => {
                         write!(
                             f,
-                            "\n    .upsert_v({}, \"{}\", {})",
+                            "\n    .upsert_v_with_defaults({}, \"{}\", {}, {})",
                             vd,
                             label,
-                            write_properties_slice(properties)
+                            write_properties_slice(properties),
+                            write_properties_slice(create_defaults)
                         )?;
                     }
                     None => {
                         write!(
                             f,
-                            "\n    .upsert_v(&[], \"{}\", {})",
+                            "\n    .upsert_v_with_defaults(&[], \"{}\", {}, {})",
                             label,
-                            write_properties_slice(properties)
+                            write_properties_slice(properties),
+                            write_properties_slice(create_defaults)
                         )?;
                     }
                 }


### PR DESCRIPTION
Fixes #864

## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues using #issue_number -->

Closes #

## Checklist when merging to main
<!-- Mark items with "x" when completed -->

- [ ] No compiler warnings (if applicable)
- [ ] Code is formatted with `rustfmt`
- [ ] No useless or dead code (if applicable)
- [ ] Code is easy to understand
- [ ] Doc comments are used for all functions, enums, structs, and fields (where appropriate)
- [ ] All tests pass
- [ ] Performance has not regressed (assuming change was not to fix a bug)
- [ ] Version number has been updated in `helix-cli/Cargo.toml` and `helixdb/Cargo.toml`

## Additional Notes
<!-- Add any additional information that would be helpful for reviewers -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully fixes bug #864 where `UpsertN` (and `UpsertE`/`UpsertV`) was ignoring schema-defined `DEFAULT` values during node creation and overwriting them during updates.

**Key changes:**
- `upsert.rs`: Adds `merge_create_props()` helper (explicit props win, defaults fill in the rest), and reworks `upsert_n/e/v` to delegate to new `_with_defaults` variants. Create path uses the merged props; update path correctly ignores `create_defaults`.
- `traversal_validation.rs`: Analyzer now collects schema `DEFAULT` fields that are **not** explicitly specified in the upsert statement and passes them as `create_defaults` to the `TraversalType` variants.
- `traversal_steps.rs`: `TraversalType::UpsertN/E/V` gains a `create_defaults` field; code generation emits `upsert_n_with_defaults` / `upsert_e_with_defaults` / `upsert_v_with_defaults` calls.
- `upsert_tests.rs`: Comprehensive test coverage added for all three upsert types (`upsert_n`, `upsert_e`, `upsert_v`) with their `_with_defaults` variants. Tests verify (a) defaults are applied on creation with explicit values overriding defaults, and (b) defaults are **not** applied when updating an existing node/edge/vector.

The implementation is consistent across all three upsert operations and correctly handles both create and update paths.

<sub>Last reviewed commit: ae1eb10</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->