### PR TITLE
rebuild BM25 from nodes and harden index invariants

### DIFF
--- a/helix-db/src/helix_engine/bm25/bm25.rs
+++ b/helix-db/src/helix_engine/bm25/bm25.rs
@@ -12,16 +12,19 @@ use bumpalo::{
     Bump,
     collections::{String as BString, Vec as BVec},
 };
-use heed3::{Database, Env, RoTxn, RwTxn, types::*};
+use heed3::{Database, DatabaseFlags, Env, RoTxn, RwTxn, byteorder::BE, types::*};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tokio::task;
 
 const DB_BM25_INVERTED_INDEX: &str = "bm25_inverted_index"; // term -> list of (doc_id, tf)
+const DB_BM25_REVERSE_INDEX: &str = "bm25_reverse_index"; // doc_id -> list of (term, tf)
 const DB_BM25_DOC_LENGTHS: &str = "bm25_doc_lengths"; // doc_id -> document length
 const DB_BM25_TERM_FREQUENCIES: &str = "bm25_term_frequencies"; // term -> document frequency
 const DB_BM25_METADATA: &str = "bm25_metadata"; // stores total docs, avgdl, etc.
 pub const METADATA_KEY: &[u8] = b"metadata";
+pub const BM25_SCHEMA_VERSION_KEY: &[u8] = b"schema_version";
+pub const BM25_SCHEMA_VERSION: u64 = 2;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct BM25Metadata {
@@ -36,6 +39,27 @@ pub struct BM25Metadata {
 pub struct PostingListEntry {
     pub doc_id: u128,
     pub term_frequency: u32,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct ReversePostingEntry {
+    pub term: String,
+    pub term_frequency: u32,
+}
+
+enum DocPresence {
+    Absent,
+    Empty,
+    Indexed(u32),
+}
+
+enum DocState {
+    Absent,
+    Empty,
+    Indexed {
+        doc_length: u32,
+        reverse_entries: Vec<ReversePostingEntry>,
+    },
 }
 
 pub trait BM25 {
@@ -69,8 +93,9 @@ pub trait BM25 {
 pub struct HBM25Config {
     pub graph_env: Env,
     pub inverted_index_db: Database<Bytes, Bytes>,
-    pub doc_lengths_db: Database<U128<heed3::byteorder::BE>, U32<heed3::byteorder::BE>>,
-    pub term_frequencies_db: Database<Bytes, U32<heed3::byteorder::BE>>,
+    pub reverse_index_db: Database<U128<BE>, Bytes>,
+    pub doc_lengths_db: Database<U128<BE>, U32<BE>>,
+    pub term_frequencies_db: Database<Bytes, U32<BE>>,
     pub metadata_db: Database<Bytes, Bytes>,
     k1: f64,
     b: f64,
@@ -81,20 +106,26 @@ impl HBM25Config {
         let inverted_index_db: Database<Bytes, Bytes> = graph_env
             .database_options()
             .types::<Bytes, Bytes>()
-            .flags(heed3::DatabaseFlags::DUP_SORT)
+            .flags(DatabaseFlags::DUP_SORT)
             .name(DB_BM25_INVERTED_INDEX)
             .create(wtxn)?;
 
-        let doc_lengths_db: Database<U128<heed3::byteorder::BE>, U32<heed3::byteorder::BE>> =
-            graph_env
-                .database_options()
-                .types::<U128<heed3::byteorder::BE>, U32<heed3::byteorder::BE>>()
-                .name(DB_BM25_DOC_LENGTHS)
-                .create(wtxn)?;
-
-        let term_frequencies_db: Database<Bytes, U32<heed3::byteorder::BE>> = graph_env
+        let reverse_index_db: Database<U128<BE>, Bytes> = graph_env
             .database_options()
-            .types::<Bytes, U32<heed3::byteorder::BE>>()
+            .types::<U128<BE>, Bytes>()
+            .flags(DatabaseFlags::DUP_SORT)
+            .name(DB_BM25_REVERSE_INDEX)
+            .create(wtxn)?;
+
+        let doc_lengths_db: Database<U128<BE>, U32<BE>> = graph_env
+            .database_options()
+            .types::<U128<BE>, U32<BE>>()
+            .name(DB_BM25_DOC_LENGTHS)
+            .create(wtxn)?;
+
+        let term_frequencies_db: Database<Bytes, U32<BE>> = graph_env
+            .database_options()
+            .types::<Bytes, U32<BE>>()
             .name(DB_BM25_TERM_FREQUENCIES)
             .create(wtxn)?;
 
@@ -107,6 +138,7 @@ impl HBM25Config {
         Ok(HBM25Config {
             graph_env: graph_env.clone(),
             inverted_index_db,
+            reverse_index_db,
             doc_lengths_db,
             term_frequencies_db,
             metadata_db,
@@ -123,20 +155,26 @@ impl HBM25Config {
         let inverted_index_db: Database<Bytes, Bytes> = graph_env
             .database_options()
             .types::<Bytes, Bytes>()
-            .flags(heed3::DatabaseFlags::DUP_SORT)
+            .flags(DatabaseFlags::DUP_SORT)
             .name(format!("{DB_BM25_INVERTED_INDEX}_{uuid}").as_str())
             .create(wtxn)?;
 
-        let doc_lengths_db: Database<U128<heed3::byteorder::BE>, U32<heed3::byteorder::BE>> =
-            graph_env
-                .database_options()
-                .types::<U128<heed3::byteorder::BE>, U32<heed3::byteorder::BE>>()
-                .name(format!("{DB_BM25_DOC_LENGTHS}_{uuid}").as_str())
-                .create(wtxn)?;
-
-        let term_frequencies_db: Database<Bytes, U32<heed3::byteorder::BE>> = graph_env
+        let reverse_index_db: Database<U128<BE>, Bytes> = graph_env
             .database_options()
-            .types::<Bytes, U32<heed3::byteorder::BE>>()
+            .types::<U128<BE>, Bytes>()
+            .flags(DatabaseFlags::DUP_SORT)
+            .name(format!("{DB_BM25_REVERSE_INDEX}_{uuid}").as_str())
+            .create(wtxn)?;
+
+        let doc_lengths_db: Database<U128<BE>, U32<BE>> = graph_env
+            .database_options()
+            .types::<U128<BE>, U32<BE>>()
+            .name(format!("{DB_BM25_DOC_LENGTHS}_{uuid}").as_str())
+            .create(wtxn)?;
+
+        let term_frequencies_db: Database<Bytes, U32<BE>> = graph_env
+            .database_options()
+            .types::<Bytes, U32<BE>>()
             .name(format!("{DB_BM25_TERM_FREQUENCIES}_{uuid}").as_str())
             .create(wtxn)?;
 
@@ -149,12 +187,332 @@ impl HBM25Config {
         Ok(HBM25Config {
             graph_env: graph_env.clone(),
             inverted_index_db,
+            reverse_index_db,
             doc_lengths_db,
             term_frequencies_db,
             metadata_db,
             k1: 1.2,
             b: 0.75,
         })
+    }
+
+    fn default_metadata(&self) -> BM25Metadata {
+        BM25Metadata {
+            total_docs: 0,
+            avgdl: 0.0,
+            k1: self.k1 as f32,
+            b: self.b as f32,
+        }
+    }
+
+    pub fn clear_all(&self, txn: &mut RwTxn) -> Result<(), GraphError> {
+        self.inverted_index_db.clear(txn)?;
+        self.reverse_index_db.clear(txn)?;
+        self.doc_lengths_db.clear(txn)?;
+        self.term_frequencies_db.clear(txn)?;
+        self.metadata_db.clear(txn)?;
+        Ok(())
+    }
+
+    pub fn schema_version(&self, txn: &RoTxn) -> Result<Option<u64>, GraphError> {
+        let Some(bytes) = self.metadata_db.get(txn, BM25_SCHEMA_VERSION_KEY)? else {
+            return Ok(None);
+        };
+
+        let Ok(version_bytes) = <[u8; std::mem::size_of::<u64>()]>::try_from(bytes) else {
+            return Ok(None);
+        };
+
+        Ok(Some(u64::from_le_bytes(version_bytes)))
+    }
+
+    pub fn write_schema_version(&self, txn: &mut RwTxn, version: u64) -> Result<(), GraphError> {
+        self.metadata_db
+            .put(txn, BM25_SCHEMA_VERSION_KEY, &version.to_le_bytes())?;
+        Ok(())
+    }
+
+    pub fn reverse_entries(
+        &self,
+        txn: &RoTxn,
+        doc_id: u128,
+    ) -> Result<Vec<ReversePostingEntry>, GraphError> {
+        let mut entries = Vec::new();
+        if let Some(duplicates) = self.reverse_index_db.get_duplicates(txn, &doc_id)? {
+            for result in duplicates {
+                let (_, entry_bytes) = result?;
+                entries.push(bincode::deserialize(entry_bytes)?);
+            }
+        }
+        Ok(entries)
+    }
+
+    fn reverse_entries_rw(
+        &self,
+        txn: &RwTxn,
+        doc_id: u128,
+    ) -> Result<Vec<ReversePostingEntry>, GraphError> {
+        let mut entries = Vec::new();
+        if let Some(duplicates) = self.reverse_index_db.get_duplicates(txn, &doc_id)? {
+            for result in duplicates {
+                let (_, entry_bytes) = result?;
+                entries.push(bincode::deserialize(entry_bytes)?);
+            }
+        }
+        Ok(entries)
+    }
+
+    fn has_reverse_entries(&self, txn: &RoTxn, doc_id: u128) -> Result<bool, GraphError> {
+        Ok(self
+            .reverse_index_db
+            .get_duplicates(txn, &doc_id)?
+            .is_some())
+    }
+
+    fn classify_doc_presence(
+        doc_id: u128,
+        doc_length: Option<u32>,
+        has_reverse_entries: bool,
+    ) -> Result<DocPresence, GraphError> {
+        match doc_length {
+            None if !has_reverse_entries => Ok(DocPresence::Absent),
+            None => Err(GraphError::New(format!(
+                "BM25 reverse index exists without doc length for document {doc_id}"
+            ))),
+            Some(0) if !has_reverse_entries => Ok(DocPresence::Empty),
+            Some(0) => Err(GraphError::New(format!(
+                "BM25 zero-length document {doc_id} has reverse entries"
+            ))),
+            Some(doc_length) if has_reverse_entries => Ok(DocPresence::Indexed(doc_length)),
+            Some(doc_length) => Err(GraphError::New(format!(
+                "BM25 document {doc_id} has doc length {doc_length} but no reverse entries"
+            ))),
+        }
+    }
+
+    fn read_metadata(&self, txn: &RwTxn) -> Result<Option<BM25Metadata>, GraphError> {
+        self.metadata_db
+            .get(txn, METADATA_KEY)?
+            .map(bincode::deserialize)
+            .transpose()
+            .map_err(GraphError::from)
+    }
+
+    fn write_metadata(&self, txn: &mut RwTxn, metadata: &BM25Metadata) -> Result<(), GraphError> {
+        let metadata_bytes = bincode::serialize(metadata)?;
+        self.metadata_db.put(txn, METADATA_KEY, &metadata_bytes)?;
+        Ok(())
+    }
+
+    fn require_metadata(&self, txn: &RwTxn, doc_id: u128) -> Result<BM25Metadata, GraphError> {
+        self.read_metadata(txn)?.ok_or_else(|| {
+            GraphError::New(format!(
+                "BM25 metadata missing for indexed document {doc_id}"
+            ))
+        })
+    }
+
+    fn term_counts(&self, doc: &str) -> HashMap<String, u32> {
+        let mut term_counts = HashMap::new();
+        for token in self.tokenize::<true>(doc) {
+            *term_counts.entry(token).or_insert(0) += 1;
+        }
+        term_counts
+    }
+
+    fn reverse_entries_from_term_counts(
+        term_counts: &HashMap<String, u32>,
+    ) -> Vec<ReversePostingEntry> {
+        let mut entries = term_counts
+            .iter()
+            .map(|(term, term_frequency)| ReversePostingEntry {
+                term: term.clone(),
+                term_frequency: *term_frequency,
+            })
+            .collect::<Vec<_>>();
+        entries.sort_by(|a, b| a.term.cmp(&b.term));
+        entries
+    }
+
+    fn replace_reverse_entries(
+        &self,
+        txn: &mut RwTxn,
+        doc_id: u128,
+        reverse_entries: &[ReversePostingEntry],
+    ) -> Result<(), GraphError> {
+        self.reverse_index_db.delete(txn, &doc_id)?;
+        for entry in reverse_entries {
+            let entry_bytes = bincode::serialize(entry)?;
+            self.reverse_index_db.put(txn, &doc_id, &entry_bytes)?;
+        }
+        Ok(())
+    }
+
+    fn insert_posting(
+        &self,
+        txn: &mut RwTxn,
+        doc_id: u128,
+        term: &str,
+        term_frequency: u32,
+    ) -> Result<(), GraphError> {
+        let term_bytes = term.as_bytes();
+        let posting_entry = PostingListEntry {
+            doc_id,
+            term_frequency,
+        };
+        let posting_bytes = bincode::serialize(&posting_entry)?;
+        self.inverted_index_db
+            .put(txn, term_bytes, &posting_bytes)?;
+
+        let current_df = self.term_frequencies_db.get(txn, term_bytes)?.unwrap_or(0);
+        self.term_frequencies_db
+            .put(txn, term_bytes, &(current_df + 1))?;
+        Ok(())
+    }
+
+    fn delete_posting(
+        &self,
+        txn: &mut RwTxn,
+        doc_id: u128,
+        term: &str,
+        term_frequency: u32,
+    ) -> Result<(), GraphError> {
+        let term_bytes = term.as_bytes();
+        let posting_entry = PostingListEntry {
+            doc_id,
+            term_frequency,
+        };
+        let posting_bytes = bincode::serialize(&posting_entry)?;
+        let deleted =
+            self.inverted_index_db
+                .delete_one_duplicate(txn, term_bytes, &posting_bytes)?;
+
+        if !deleted {
+            return Err(GraphError::New(format!(
+                "BM25 posting missing while deleting term '{term}' for document {doc_id}"
+            )));
+        }
+
+        let current_df = self
+            .term_frequencies_db
+            .get(txn, term_bytes)?
+            .ok_or_else(|| {
+                GraphError::New(format!(
+                    "BM25 term frequency missing while deleting term '{term}'"
+                ))
+            })?;
+
+        if current_df <= 1 {
+            self.term_frequencies_db.delete(txn, term_bytes)?;
+        } else {
+            self.term_frequencies_db
+                .put(txn, term_bytes, &(current_df - 1))?;
+        }
+
+        Ok(())
+    }
+
+    fn doc_state(&self, txn: &RwTxn, doc_id: u128) -> Result<DocState, GraphError> {
+        let reverse_entries = self.reverse_entries_rw(txn, doc_id)?;
+        match Self::classify_doc_presence(
+            doc_id,
+            self.doc_lengths_db.get(txn, &doc_id)?,
+            !reverse_entries.is_empty(),
+        )? {
+            DocPresence::Absent => Ok(DocState::Absent),
+            DocPresence::Empty => Ok(DocState::Empty),
+            DocPresence::Indexed(doc_length) => Ok(DocState::Indexed {
+                doc_length,
+                reverse_entries,
+            }),
+        }
+    }
+
+    fn validate_search_doc(&self, txn: &RoTxn, doc_id: u128) -> Result<u32, GraphError> {
+        match Self::classify_doc_presence(
+            doc_id,
+            self.doc_lengths_db.get(txn, &doc_id)?,
+            self.has_reverse_entries(txn, doc_id)?,
+        )? {
+            DocPresence::Indexed(doc_length) => Ok(doc_length),
+            DocPresence::Absent => Err(GraphError::New(format!(
+                "BM25 posting exists for absent document {doc_id}"
+            ))),
+            DocPresence::Empty => Err(GraphError::New(format!(
+                "BM25 posting exists for empty document {doc_id}"
+            ))),
+        }
+    }
+
+    fn record_insert(&self, txn: &mut RwTxn, doc_length: u32) -> Result<(), GraphError> {
+        let mut metadata = self
+            .read_metadata(txn)?
+            .unwrap_or_else(|| self.default_metadata());
+        let old_total_docs = metadata.total_docs;
+        metadata.total_docs += 1;
+        metadata.avgdl = (metadata.avgdl * old_total_docs as f64 + doc_length as f64)
+            / metadata.total_docs as f64;
+        self.write_metadata(txn, &metadata)
+    }
+
+    fn record_delete(
+        &self,
+        txn: &mut RwTxn,
+        doc_id: u128,
+        doc_length: u32,
+    ) -> Result<(), GraphError> {
+        let mut metadata = self.require_metadata(txn, doc_id)?;
+        if metadata.total_docs == 0 {
+            return Err(GraphError::New(format!(
+                "BM25 metadata total_docs is zero while deleting document {doc_id}"
+            )));
+        }
+
+        metadata.avgdl = if metadata.total_docs > 1 {
+            (metadata.avgdl * metadata.total_docs as f64 - doc_length as f64)
+                / (metadata.total_docs - 1) as f64
+        } else {
+            0.0
+        };
+        metadata.total_docs -= 1;
+        self.write_metadata(txn, &metadata)
+    }
+
+    fn record_update(
+        &self,
+        txn: &mut RwTxn,
+        doc_id: u128,
+        old_doc_length: u32,
+        new_doc_length: u32,
+    ) -> Result<(), GraphError> {
+        let mut metadata = self.require_metadata(txn, doc_id)?;
+        if metadata.total_docs == 0 {
+            return Err(GraphError::New(format!(
+                "BM25 metadata total_docs is zero while updating document {doc_id}"
+            )));
+        }
+
+        metadata.avgdl = (metadata.avgdl * metadata.total_docs as f64 - old_doc_length as f64
+            + new_doc_length as f64)
+            / metadata.total_docs as f64;
+        self.write_metadata(txn, &metadata)
+    }
+
+    fn insert_new_document(
+        &self,
+        txn: &mut RwTxn,
+        doc_id: u128,
+        term_counts: &HashMap<String, u32>,
+        doc_length: u32,
+    ) -> Result<(), GraphError> {
+        let reverse_entries = Self::reverse_entries_from_term_counts(term_counts);
+
+        self.doc_lengths_db.put(txn, &doc_id, &doc_length)?;
+        for entry in &reverse_entries {
+            self.insert_posting(txn, doc_id, &entry.term, entry.term_frequency)?;
+        }
+        self.replace_reverse_entries(txn, doc_id, &reverse_entries)?;
+        self.record_insert(txn, doc_length)
     }
 }
 
@@ -168,138 +526,78 @@ impl BM25 for HBM25Config {
             .collect()
     }
 
-    /// Inserts needed information into doc_lengths_db, inverted_index_db, term_frequencies_db, and
-    /// metadata_db
     fn insert_doc(&self, txn: &mut RwTxn, doc_id: u128, doc: &str) -> Result<(), GraphError> {
-        let tokens = self.tokenize::<true>(doc);
-        let doc_length = tokens.len() as u32;
-
-        let mut term_counts: HashMap<String, u32> = HashMap::new();
-        for token in tokens {
-            *term_counts.entry(token).or_insert(0) += 1;
+        if !matches!(self.doc_state(txn, doc_id)?, DocState::Absent) {
+            return Err(GraphError::New(format!(
+                "BM25 document {doc_id} already exists"
+            )));
         }
 
-        self.doc_lengths_db.put(txn, &doc_id, &doc_length)?;
-
-        for (term, tf) in term_counts {
-            let term_bytes = term.as_bytes();
-
-            let posting_entry = PostingListEntry {
-                doc_id,
-                term_frequency: tf,
-            };
-
-            let posting_bytes = bincode::serialize(&posting_entry)?;
-
-            self.inverted_index_db
-                .put(txn, term_bytes, &posting_bytes)?;
-
-            let current_df = self.term_frequencies_db.get(txn, term_bytes)?.unwrap_or(0);
-            self.term_frequencies_db
-                .put(txn, term_bytes, &(current_df + 1))?;
-        }
-
-        let mut metadata = if let Some(data) = self.metadata_db.get(txn, METADATA_KEY)? {
-            bincode::deserialize::<BM25Metadata>(data)?
-        } else {
-            BM25Metadata {
-                total_docs: 0,
-                avgdl: 0.0,
-                k1: 1.2,
-                b: 0.75,
-            }
-        };
-
-        let old_total_docs = metadata.total_docs;
-        metadata.total_docs += 1;
-        metadata.avgdl = (metadata.avgdl * old_total_docs as f64 + doc_length as f64)
-            / metadata.total_docs as f64;
-
-        let metadata_bytes = bincode::serialize(&metadata)?;
-        self.metadata_db.put(txn, METADATA_KEY, &metadata_bytes)?;
-
-        Ok(())
+        let term_counts = self.term_counts(doc);
+        let doc_length = term_counts.values().copied().sum();
+        self.insert_new_document(txn, doc_id, &term_counts, doc_length)
     }
 
     fn delete_doc(&self, txn: &mut RwTxn, doc_id: u128) -> Result<(), GraphError> {
-        let terms_to_update = {
-            let mut terms = Vec::new();
-            let mut iter = self.inverted_index_db.iter(txn)?;
-
-            while let Some((term_bytes, posting_bytes)) = iter.next().transpose()? {
-                let posting: PostingListEntry = bincode::deserialize(posting_bytes)?;
-                if posting.doc_id == doc_id {
-                    terms.push(term_bytes.to_vec());
-                }
-            }
-            terms
+        let (doc_length, reverse_entries) = match self.doc_state(txn, doc_id)? {
+            DocState::Absent => return Ok(()),
+            DocState::Empty => (0, Vec::new()),
+            DocState::Indexed {
+                doc_length,
+                reverse_entries,
+            } => (doc_length, reverse_entries),
         };
 
-        // remove postings and update term frequencies
-        for term_bytes in terms_to_update {
-            // collect entries to keep
-            let entries_to_keep = {
-                let mut entries = Vec::new();
-                if let Some(duplicates) = self.inverted_index_db.get_duplicates(txn, &term_bytes)? {
-                    for result in duplicates {
-                        let (_, posting_bytes) = result?;
-                        let posting: PostingListEntry = bincode::deserialize(posting_bytes)?;
-                        if posting.doc_id != doc_id {
-                            entries.push(posting_bytes.to_vec());
-                        }
-                    }
-                }
-                entries
-            };
-
-            // delete all entries for this term
-            self.inverted_index_db.delete(txn, &term_bytes)?;
-
-            // re-add the entries we want to keep
-            for entry_bytes in entries_to_keep {
-                self.inverted_index_db.put(txn, &term_bytes, &entry_bytes)?;
-            }
-
-            let current_df = self.term_frequencies_db.get(txn, &term_bytes)?.unwrap_or(0);
-            if current_df > 0 {
-                self.term_frequencies_db
-                    .put(txn, &term_bytes, &(current_df - 1))?;
-            }
+        for entry in &reverse_entries {
+            self.delete_posting(txn, doc_id, &entry.term, entry.term_frequency)?;
         }
 
-        let doc_length = self.doc_lengths_db.get(txn, &doc_id)?.unwrap_or(0);
-
+        self.reverse_index_db.delete(txn, &doc_id)?;
         self.doc_lengths_db.delete(txn, &doc_id)?;
-
-        let metadata_data = self
-            .metadata_db
-            .get(txn, METADATA_KEY)?
-            .map(|data| data.to_vec());
-
-        if let Some(data) = metadata_data {
-            let mut metadata: BM25Metadata = bincode::deserialize(&data)?;
-            if metadata.total_docs > 0 {
-                // update average document length
-                metadata.avgdl = if metadata.total_docs > 1 {
-                    (metadata.avgdl * metadata.total_docs as f64 - doc_length as f64)
-                        / (metadata.total_docs - 1) as f64
-                } else {
-                    0.0
-                };
-                metadata.total_docs -= 1;
-
-                let metadata_bytes = bincode::serialize(&metadata)?;
-                self.metadata_db.put(txn, METADATA_KEY, &metadata_bytes)?;
-            }
-        }
-
-        Ok(())
+        self.record_delete(txn, doc_id, doc_length)
     }
 
-    /// Simply delete doc_id and then re-insert new doc with same doc-id
     fn update_doc(&self, txn: &mut RwTxn, doc_id: u128, doc: &str) -> Result<(), GraphError> {
-        self.delete_doc(txn, doc_id)?;
-        self.insert_doc(txn, doc_id, doc)
+        let new_term_counts = self.term_counts(doc);
+        let new_doc_length = new_term_counts.values().copied().sum();
+
+        let (old_doc_length, old_reverse_entries) = match self.doc_state(txn, doc_id)? {
+            DocState::Absent => {
+                return self.insert_new_document(txn, doc_id, &new_term_counts, new_doc_length);
+            }
+            DocState::Empty => (0, Vec::new()),
+            DocState::Indexed {
+                doc_length,
+                reverse_entries,
+            } => (doc_length, reverse_entries),
+        };
+
+        let mut old_term_counts = HashMap::new();
+        for entry in &old_reverse_entries {
+            old_term_counts.insert(entry.term.clone(), entry.term_frequency);
+        }
+
+        for (term, old_term_frequency) in &old_term_counts {
+            match new_term_counts.get(term) {
+                Some(new_term_frequency) if *new_term_frequency == *old_term_frequency => {}
+                Some(new_term_frequency) => {
+                    self.delete_posting(txn, doc_id, term, *old_term_frequency)?;
+                    self.insert_posting(txn, doc_id, term, *new_term_frequency)?;
+                }
+                None => self.delete_posting(txn, doc_id, term, *old_term_frequency)?,
+            }
+        }
+
+        for (term, new_term_frequency) in &new_term_counts {
+            if !old_term_counts.contains_key(term) {
+                self.insert_posting(txn, doc_id, term, *new_term_frequency)?;
+            }
+        }
+
+        let new_reverse_entries = Self::reverse_entries_from_term_counts(&new_term_counts);
+        self.replace_reverse_entries(txn, doc_id, &new_reverse_entries)?;
+        self.doc_lengths_db.put(txn, &doc_id, &new_doc_length)?;
+        self.record_update(txn, doc_id, old_doc_length, new_doc_length)
     }
 
     fn calculate_bm25_score(
@@ -343,15 +641,18 @@ impl BM25 for HBM25Config {
                 .map(|s| BString::from_str_in(&s, arena)),
             arena,
         );
+
+        let Some(metadata_bytes) = self.metadata_db.get(txn, METADATA_KEY)? else {
+            return Ok(Vec::new());
+        };
+        let metadata: BM25Metadata = bincode::deserialize(metadata_bytes)?;
+        if metadata.total_docs == 0 {
+            return Ok(Vec::new());
+        }
+
         // (node uuid, score)
         let estimated_capacity = (query_terms.len() * 50).min(limit * 4);
         let mut doc_scores: HashMap<u128, f32> = HashMap::with_capacity(estimated_capacity);
-
-        let metadata = self
-            .metadata_db
-            .get(txn, METADATA_KEY)?
-            .ok_or(GraphError::New("BM25 metadata not found".to_string()))?;
-        let metadata: BM25Metadata = bincode::deserialize(metadata)?;
 
         // for each query term, calculate scores
         for term in query_terms {
@@ -369,7 +670,7 @@ impl BM25 for HBM25Config {
                     let posting: PostingListEntry = bincode::deserialize(posting_bytes)?;
 
                     // Get document length
-                    let doc_length = self.doc_lengths_db.get(txn, &posting.doc_id)?.unwrap_or(0);
+                    let doc_length = self.validate_search_doc(txn, posting.doc_id)?;
 
                     // Calculate BM25 score for this term in this document
                     let score = self.calculate_bm25_score(
@@ -386,7 +687,6 @@ impl BM25 for HBM25Config {
         }
 
         // Sort by score and return top results
-        // Pre-allocate with exact capacity to avoid reallocation during collection
         let mut results: Vec<(u128, f32)> = Vec::with_capacity(doc_scores.len());
         results.extend(doc_scores);
         results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
@@ -435,7 +735,7 @@ impl HybridSearch for HelixGraphStorage {
         let vector_handle =
             task::spawn_blocking(move || -> Result<Option<Vec<(u128, f64)>>, GraphError> {
                 let txn = graph_env_vector.read_txn()?;
-                let arena = Bump::new(); // MOVE
+                let arena = Bump::new();
                 let query_slice = arena.alloc_slice_copy(query_vector_owned.as_slice());
                 let results = self.vectors.search::<fn(&HVector, &RoTxn) -> bool>(
                     &txn,
@@ -471,11 +771,10 @@ impl HybridSearch for HelixGraphStorage {
                 combined_scores
                     .entry(doc_id)
                     .and_modify(|existing_score| *existing_score += (1.0 - alpha) * similarity)
-                    .or_insert((1.0 - alpha) * similarity); // correction made here from score as f32 to similarity
+                    .or_insert((1.0 - alpha) * similarity);
             }
         }
 
-        // Pre-allocate with exact capacity to avoid reallocation during collection
         let mut results = Vec::with_capacity(combined_scores.len());
         results.extend(combined_scores);
         results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
@@ -483,6 +782,12 @@ impl HybridSearch for HelixGraphStorage {
 
         Ok(results)
     }
+}
+
+pub fn build_bm25_payload(properties: &ImmutablePropertiesMap<'_>, label: &str) -> String {
+    let mut data = properties.flatten_bm25();
+    data.push_str(label);
+    data
 }
 
 pub trait BM25Flatten {

--- a/helix-db/src/helix_engine/bm25/bm25_tests.rs
+++ b/helix-db/src/helix_engine/bm25/bm25_tests.rs
@@ -3,7 +3,8 @@ mod tests {
     use crate::{
         helix_engine::{
             bm25::bm25::{
-                BM25, BM25Flatten, BM25Metadata, HBM25Config, HybridSearch, METADATA_KEY,
+                BM25, BM25_SCHEMA_VERSION, BM25_SCHEMA_VERSION_KEY, BM25Flatten, BM25Metadata,
+                HBM25Config, HybridSearch, METADATA_KEY, PostingListEntry, ReversePostingEntry,
             },
             storage_core::{HelixGraphStorage, version_info::VersionInfo},
             traversal_core::config::Config,
@@ -48,6 +49,10 @@ mod tests {
         let config = Config::default();
         let storage = HelixGraphStorage::new(path, config, VersionInfo::default()).unwrap();
         (storage, temp_dir)
+    }
+
+    fn reverse_entries(bm25: &HBM25Config, txn: &RoTxn, doc_id: u128) -> Vec<ReversePostingEntry> {
+        bm25.reverse_entries(txn, doc_id).unwrap()
     }
 
     fn generate_random_vectors(n: usize, d: usize) -> Vec<Vec<f64>> {
@@ -132,6 +137,10 @@ mod tests {
         assert!(metadata.avgdl > 0.0);
 
         wtxn.commit().unwrap();
+
+        let rtxn = bm25.graph_env.read_txn().unwrap();
+        let reverse_entries = reverse_entries(&bm25, &rtxn, doc_id);
+        assert!(!reverse_entries.is_empty());
     }
 
     #[test]
@@ -1341,6 +1350,59 @@ mod tests {
         let results = bm25.search(&rtxn, "updated", 10, &arena).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].0, doc_id);
+
+        let stale_results = bm25.search(&rtxn, "original", 10, &arena).unwrap();
+        assert!(stale_results.is_empty());
+
+        let reverse_entries = reverse_entries(&bm25, &rtxn, doc_id);
+        assert!(reverse_entries.iter().any(|entry| entry.term == "updated"));
+        assert!(!reverse_entries.iter().any(|entry| entry.term == "original"));
+    }
+
+    #[test]
+    fn test_update_document_non_empty_to_empty() {
+        let (bm25, _temp_dir) = setup_bm25_config();
+        let mut wtxn = bm25.graph_env.write_txn().unwrap();
+
+        let doc_id = 1u128;
+        bm25.insert_doc(&mut wtxn, doc_id, "searchable content")
+            .unwrap();
+        bm25.update_doc(&mut wtxn, doc_id, "an to of").unwrap();
+
+        let doc_length = bm25.doc_lengths_db.get(&wtxn, &doc_id).unwrap().unwrap();
+        assert_eq!(doc_length, 0);
+        wtxn.commit().unwrap();
+
+        let rtxn = bm25.graph_env.read_txn().unwrap();
+        let arena = Bump::new();
+        assert!(
+            bm25.search(&rtxn, "searchable", 10, &arena)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(reverse_entries(&bm25, &rtxn, doc_id).is_empty());
+    }
+
+    #[test]
+    fn test_update_document_empty_to_non_empty() {
+        let (bm25, _temp_dir) = setup_bm25_config();
+        let mut wtxn = bm25.graph_env.write_txn().unwrap();
+
+        let doc_id = 1u128;
+        bm25.insert_doc(&mut wtxn, doc_id, "an to of").unwrap();
+        bm25.update_doc(&mut wtxn, doc_id, "fresh searchable content")
+            .unwrap();
+
+        let doc_length = bm25.doc_lengths_db.get(&wtxn, &doc_id).unwrap().unwrap();
+        assert!(doc_length > 0);
+        wtxn.commit().unwrap();
+
+        let rtxn = bm25.graph_env.read_txn().unwrap();
+        let arena = Bump::new();
+        let results = bm25.search(&rtxn, "fresh", 10, &arena).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, doc_id);
+        assert!(!reverse_entries(&bm25, &rtxn, doc_id).is_empty());
     }
 
     #[test]
@@ -1366,6 +1428,13 @@ mod tests {
         let doc_length = bm25.doc_lengths_db.get(&wtxn, &2u128).unwrap();
         assert!(doc_length.is_none());
 
+        assert!(
+            bm25.reverse_index_db
+                .get_duplicates(&wtxn, &2u128)
+                .unwrap()
+                .is_none()
+        );
+
         // check that metadata was updated
         let metadata_bytes = bm25.metadata_db.get(&wtxn, METADATA_KEY).unwrap().unwrap();
         let metadata: BM25Metadata = bincode::deserialize(metadata_bytes).unwrap();
@@ -1378,6 +1447,300 @@ mod tests {
         let arena = Bump::new();
         let results = bm25.search(&rtxn, "two", 10, &arena).unwrap();
         assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn test_delete_document_twice_is_noop() {
+        let (bm25, _temp_dir) = setup_bm25_config();
+        let mut wtxn = bm25.graph_env.write_txn().unwrap();
+
+        bm25.insert_doc(&mut wtxn, 1u128, "content to delete")
+            .unwrap();
+        bm25.delete_doc(&mut wtxn, 1u128).unwrap();
+        bm25.delete_doc(&mut wtxn, 1u128).unwrap();
+
+        let metadata: BM25Metadata =
+            bincode::deserialize(bm25.metadata_db.get(&wtxn, METADATA_KEY).unwrap().unwrap())
+                .unwrap();
+        assert_eq!(metadata.total_docs, 0);
+        wtxn.commit().unwrap();
+    }
+
+    #[test]
+    fn test_delete_document_errors_when_reverse_exists_without_doc_length() {
+        let (bm25, _temp_dir) = setup_bm25_config();
+        let mut wtxn = bm25.graph_env.write_txn().unwrap();
+
+        let reverse_entry = ReversePostingEntry {
+            term: "ghost".to_string(),
+            term_frequency: 1,
+        };
+        let reverse_bytes = bincode::serialize(&reverse_entry).unwrap();
+        bm25.reverse_index_db
+            .put(&mut wtxn, &1u128, &reverse_bytes)
+            .unwrap();
+
+        let err = bm25.delete_doc(&mut wtxn, 1u128).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("reverse index exists without doc length")
+        );
+    }
+
+    #[test]
+    fn test_update_document_errors_when_reverse_exists_without_doc_length() {
+        let (bm25, _temp_dir) = setup_bm25_config();
+        let mut wtxn = bm25.graph_env.write_txn().unwrap();
+
+        let reverse_entry = ReversePostingEntry {
+            term: "ghost".to_string(),
+            term_frequency: 1,
+        };
+        let reverse_bytes = bincode::serialize(&reverse_entry).unwrap();
+        bm25.reverse_index_db
+            .put(&mut wtxn, &1u128, &reverse_bytes)
+            .unwrap();
+
+        let err = bm25
+            .update_doc(&mut wtxn, 1u128, "new content")
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("reverse index exists without doc length")
+        );
+    }
+
+    #[test]
+    fn test_delete_document_errors_when_positive_doc_length_has_no_reverse_entries() {
+        let (bm25, _temp_dir) = setup_bm25_config();
+        let mut wtxn = bm25.graph_env.write_txn().unwrap();
+
+        let metadata = BM25Metadata {
+            total_docs: 1,
+            avgdl: 3.0,
+            k1: 1.2,
+            b: 0.75,
+        };
+        bm25.doc_lengths_db.put(&mut wtxn, &1u128, &3).unwrap();
+        bm25.metadata_db
+            .put(
+                &mut wtxn,
+                METADATA_KEY,
+                &bincode::serialize(&metadata).unwrap(),
+            )
+            .unwrap();
+
+        let err = bm25.delete_doc(&mut wtxn, 1u128).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("has doc length 3 but no reverse entries")
+        );
+    }
+
+    #[test]
+    fn test_update_document_errors_when_positive_doc_length_has_no_reverse_entries() {
+        let (bm25, _temp_dir) = setup_bm25_config();
+        let mut wtxn = bm25.graph_env.write_txn().unwrap();
+
+        let metadata = BM25Metadata {
+            total_docs: 1,
+            avgdl: 3.0,
+            k1: 1.2,
+            b: 0.75,
+        };
+        bm25.doc_lengths_db.put(&mut wtxn, &1u128, &3).unwrap();
+        bm25.metadata_db
+            .put(
+                &mut wtxn,
+                METADATA_KEY,
+                &bincode::serialize(&metadata).unwrap(),
+            )
+            .unwrap();
+
+        let err = bm25
+            .update_doc(&mut wtxn, 1u128, "new content")
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("has doc length 3 but no reverse entries")
+        );
+    }
+
+    #[test]
+    fn test_delete_document_errors_when_zero_length_doc_has_reverse_entries() {
+        let (bm25, _temp_dir) = setup_bm25_config();
+        let mut wtxn = bm25.graph_env.write_txn().unwrap();
+
+        let metadata = BM25Metadata {
+            total_docs: 1,
+            avgdl: 0.0,
+            k1: 1.2,
+            b: 0.75,
+        };
+        let reverse_entry = ReversePostingEntry {
+            term: "ghost".to_string(),
+            term_frequency: 1,
+        };
+
+        bm25.doc_lengths_db.put(&mut wtxn, &1u128, &0).unwrap();
+        bm25.reverse_index_db
+            .put(
+                &mut wtxn,
+                &1u128,
+                &bincode::serialize(&reverse_entry).unwrap(),
+            )
+            .unwrap();
+        bm25.metadata_db
+            .put(
+                &mut wtxn,
+                METADATA_KEY,
+                &bincode::serialize(&metadata).unwrap(),
+            )
+            .unwrap();
+
+        let err = bm25.delete_doc(&mut wtxn, 1u128).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("zero-length document 1 has reverse entries")
+        );
+    }
+
+    #[test]
+    fn test_search_errors_when_posting_doc_is_absent() {
+        let (bm25, _temp_dir) = setup_bm25_config();
+        let mut wtxn = bm25.graph_env.write_txn().unwrap();
+
+        let metadata = BM25Metadata {
+            total_docs: 1,
+            avgdl: 1.0,
+            k1: 1.2,
+            b: 0.75,
+        };
+        let posting = PostingListEntry {
+            doc_id: 1u128,
+            term_frequency: 1,
+        };
+
+        bm25.inverted_index_db
+            .put(&mut wtxn, b"ghost", &bincode::serialize(&posting).unwrap())
+            .unwrap();
+        bm25.term_frequencies_db
+            .put(&mut wtxn, b"ghost", &1)
+            .unwrap();
+        bm25.metadata_db
+            .put(
+                &mut wtxn,
+                METADATA_KEY,
+                &bincode::serialize(&metadata).unwrap(),
+            )
+            .unwrap();
+        wtxn.commit().unwrap();
+
+        let rtxn = bm25.graph_env.read_txn().unwrap();
+        let arena = Bump::new();
+        let err = bm25.search(&rtxn, "ghost", 10, &arena).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("posting exists for absent document 1")
+        );
+    }
+
+    #[test]
+    fn test_search_errors_when_zero_length_doc_has_reverse_entries() {
+        let (bm25, _temp_dir) = setup_bm25_config();
+        let mut wtxn = bm25.graph_env.write_txn().unwrap();
+
+        let metadata = BM25Metadata {
+            total_docs: 1,
+            avgdl: 1.0,
+            k1: 1.2,
+            b: 0.75,
+        };
+        let posting = PostingListEntry {
+            doc_id: 1u128,
+            term_frequency: 1,
+        };
+        let reverse_entry = ReversePostingEntry {
+            term: "ghost".to_string(),
+            term_frequency: 1,
+        };
+
+        bm25.inverted_index_db
+            .put(&mut wtxn, b"ghost", &bincode::serialize(&posting).unwrap())
+            .unwrap();
+        bm25.term_frequencies_db
+            .put(&mut wtxn, b"ghost", &1)
+            .unwrap();
+        bm25.doc_lengths_db.put(&mut wtxn, &1u128, &0).unwrap();
+        bm25.reverse_index_db
+            .put(
+                &mut wtxn,
+                &1u128,
+                &bincode::serialize(&reverse_entry).unwrap(),
+            )
+            .unwrap();
+        bm25.metadata_db
+            .put(
+                &mut wtxn,
+                METADATA_KEY,
+                &bincode::serialize(&metadata).unwrap(),
+            )
+            .unwrap();
+        wtxn.commit().unwrap();
+
+        let rtxn = bm25.graph_env.read_txn().unwrap();
+        let arena = Bump::new();
+        let err = bm25.search(&rtxn, "ghost", 10, &arena).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("zero-length document 1 has reverse entries")
+        );
+    }
+
+    #[test]
+    fn test_delete_document_errors_when_forward_posting_missing_and_df_stays_unchanged() {
+        let (bm25, _temp_dir) = setup_bm25_config();
+        let mut wtxn = bm25.graph_env.write_txn().unwrap();
+
+        let metadata = BM25Metadata {
+            total_docs: 1,
+            avgdl: 1.0,
+            k1: 1.2,
+            b: 0.75,
+        };
+        let reverse_entry = ReversePostingEntry {
+            term: "ghost".to_string(),
+            term_frequency: 1,
+        };
+
+        bm25.doc_lengths_db.put(&mut wtxn, &1u128, &1).unwrap();
+        bm25.reverse_index_db
+            .put(
+                &mut wtxn,
+                &1u128,
+                &bincode::serialize(&reverse_entry).unwrap(),
+            )
+            .unwrap();
+        bm25.term_frequencies_db
+            .put(&mut wtxn, b"ghost", &1)
+            .unwrap();
+        bm25.metadata_db
+            .put(
+                &mut wtxn,
+                METADATA_KEY,
+                &bincode::serialize(&metadata).unwrap(),
+            )
+            .unwrap();
+
+        let err = bm25.delete_doc(&mut wtxn, 1u128).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("posting missing while deleting term 'ghost' for document 1")
+        );
+        assert_eq!(
+            bm25.term_frequencies_db.get(&wtxn, b"ghost").unwrap(),
+            Some(1)
+        );
     }
 
     #[test]
@@ -1850,6 +2213,31 @@ mod tests {
         let arena = Bump::new();
         let results = config.search(&rtxn, "test", 10, &arena).unwrap();
         assert_eq!(results.len(), 1);
+
+        let reverse_entries = reverse_entries(&config, &rtxn, 1u128);
+        assert_eq!(reverse_entries.len(), 2);
+    }
+
+    #[test]
+    fn test_schema_version_round_trip() {
+        let (bm25, _temp_dir) = setup_bm25_config();
+        let mut wtxn = bm25.graph_env.write_txn().unwrap();
+        bm25.write_schema_version(&mut wtxn, BM25_SCHEMA_VERSION)
+            .unwrap();
+        wtxn.commit().unwrap();
+
+        let rtxn = bm25.graph_env.read_txn().unwrap();
+        assert_eq!(
+            bm25.schema_version(&rtxn).unwrap(),
+            Some(BM25_SCHEMA_VERSION)
+        );
+        assert_eq!(
+            bm25.metadata_db
+                .get(&rtxn, BM25_SCHEMA_VERSION_KEY)
+                .unwrap()
+                .unwrap(),
+            BM25_SCHEMA_VERSION.to_le_bytes().as_slice()
+        );
     }
 
     #[test]

--- a/helix-db/src/helix_engine/storage_core/storage_migration.rs
+++ b/helix-db/src/helix_engine/storage_core/storage_migration.rs
@@ -1,11 +1,12 @@
 use crate::{
     helix_engine::{
+        bm25::bm25::{BM25, BM25_SCHEMA_VERSION, build_bm25_payload},
         storage_core::HelixGraphStorage,
         types::GraphError,
         vector_core::{vector::HVector, vector_core},
     },
     protocol::value::Value,
-    utils::properties::ImmutablePropertiesMap,
+    utils::{items::Node, properties::ImmutablePropertiesMap},
 };
 use bincode::Options;
 use itertools::Itertools;
@@ -38,7 +39,76 @@ pub fn migrate(storage: &mut HelixGraphStorage) -> Result<(), GraphError> {
 
     verify_vectors_and_repair(storage)?;
     remove_orphaned_vector_edges(storage)?;
+    migrate_bm25(storage)?;
 
+    Ok(())
+}
+
+fn migrate_bm25(storage: &mut HelixGraphStorage) -> Result<(), GraphError> {
+    const BATCH_SIZE: usize = 1024;
+
+    let Some(bm25) = storage.bm25.as_ref() else {
+        return Ok(());
+    };
+
+    let current_schema_version = {
+        let txn = storage.graph_env.read_txn()?;
+        bm25.schema_version(&txn)?
+    };
+
+    if current_schema_version == Some(BM25_SCHEMA_VERSION) {
+        return Ok(());
+    }
+
+    {
+        let mut txn = storage.graph_env.write_txn()?;
+        bm25.clear_all(&mut txn)?;
+        txn.commit()?;
+    }
+
+    let read_txn = storage.graph_env.read_txn()?;
+    let mut batch = Vec::with_capacity(BATCH_SIZE);
+
+    for kv in storage.nodes_db.iter(&read_txn)? {
+        let (id, value) = kv?;
+        batch.push((id, value.to_vec()));
+
+        if batch.len() == BATCH_SIZE {
+            rebuild_bm25_batch(storage, bm25, &batch)?;
+            batch.clear();
+        }
+    }
+
+    drop(read_txn);
+
+    if !batch.is_empty() {
+        rebuild_bm25_batch(storage, bm25, &batch)?;
+    }
+
+    let mut txn = storage.graph_env.write_txn()?;
+    bm25.write_schema_version(&mut txn, BM25_SCHEMA_VERSION)?;
+    txn.commit()?;
+
+    Ok(())
+}
+
+fn rebuild_bm25_batch(
+    storage: &HelixGraphStorage,
+    bm25: &crate::helix_engine::bm25::bm25::HBM25Config,
+    batch: &[(u128, Vec<u8>)],
+) -> Result<(), GraphError> {
+    let arena = bumpalo::Bump::new();
+    let mut txn = storage.graph_env.write_txn()?;
+
+    for (id, value) in batch {
+        let node = Node::from_bincode_bytes(*id, value, &arena)?;
+        if let Some(properties) = node.properties.as_ref() {
+            let data = build_bm25_payload(properties, node.label);
+            bm25.insert_doc(&mut txn, *id, &data)?;
+        }
+    }
+
+    txn.commit()?;
     Ok(())
 }
 

--- a/helix-db/src/helix_engine/storage_core/storage_migration_tests.rs
+++ b/helix-db/src/helix_engine/storage_core/storage_migration_tests.rs
@@ -9,19 +9,29 @@
 //! - Performance tests for large datasets
 
 use super::{
-    metadata::{StorageMetadata, VectorEndianness, NATIVE_VECTOR_ENDIANNESS},
+    HelixGraphStorage,
+    metadata::{NATIVE_VECTOR_ENDIANNESS, StorageMetadata, VectorEndianness},
     storage_migration::{
         convert_all_vector_properties, convert_old_vector_properties_to_new_format,
         convert_vector_endianness, migrate,
     },
-    HelixGraphStorage,
 };
 use crate::{
     helix_engine::{
-        storage_core::version_info::VersionInfo, traversal_core::config::Config, types::GraphError,
+        bm25::bm25::{
+            BM25, BM25_SCHEMA_VERSION, BM25_SCHEMA_VERSION_KEY, BM25Metadata, METADATA_KEY,
+        },
+        storage_core::version_info::VersionInfo,
+        traversal_core::{
+            config::Config,
+            ops::{g::G, source::add_n::AddNAdapter},
+        },
+        types::GraphError,
     },
     protocol::value::Value,
+    utils::{items::Node, properties::ImmutablePropertiesMap},
 };
+use bumpalo::Bump;
 use std::collections::HashMap;
 use tempfile::TempDir;
 
@@ -167,6 +177,45 @@ fn clear_metadata(storage: &mut HelixGraphStorage) -> Result<(), GraphError> {
     storage.metadata_db.clear(&mut txn)?;
     txn.commit()?;
     Ok(())
+}
+
+fn add_test_node(
+    storage: &HelixGraphStorage,
+    label: &'static str,
+    properties: &[(&'static str, Value)],
+) -> u128 {
+    let arena = Bump::new();
+    let properties = if properties.is_empty() {
+        None
+    } else {
+        Some(ImmutablePropertiesMap::new(
+            properties.len(),
+            properties.iter().map(|(key, value)| (*key, value.clone())),
+            &arena,
+        ))
+    };
+    let mut txn = storage.graph_env.write_txn().unwrap();
+    let node = G::new_mut(storage, &arena, &mut txn)
+        .add_n(label, properties, None)
+        .collect_to_obj()
+        .unwrap();
+    let node_id = node.id();
+    txn.commit().unwrap();
+    node_id
+}
+
+fn bm25_search_ids(storage: &HelixGraphStorage, query: &str) -> Vec<u128> {
+    let arena = Bump::new();
+    let txn = storage.graph_env.read_txn().unwrap();
+    storage
+        .bm25
+        .as_ref()
+        .unwrap()
+        .search(&txn, query, 10, &arena)
+        .unwrap()
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect()
 }
 
 // ============================================================================
@@ -958,6 +1007,140 @@ fn test_error_handling_graceful_failure() {
     let txn = storage.graph_env.read_txn().unwrap();
     let count = storage.vectors.vectors_db.len(&txn).unwrap();
     assert_eq!(count, 11); // 10 valid + 1 invalid
+}
+
+#[test]
+fn test_bm25_migration_rerun_is_noop_once_schema_written() {
+    let (mut storage, _temp_dir) = setup_test_storage();
+    let node_id = add_test_node(&storage, "person", &[("name", Value::from("stable_term"))]);
+
+    let before_metadata = {
+        let txn = storage.graph_env.read_txn().unwrap();
+        let bm25 = storage.bm25.as_ref().unwrap();
+        assert_eq!(
+            bm25.schema_version(&txn).unwrap(),
+            Some(BM25_SCHEMA_VERSION)
+        );
+        bm25.metadata_db
+            .get(&txn, METADATA_KEY)
+            .unwrap()
+            .map(|bytes| bytes.to_vec())
+    };
+    let before_results = bm25_search_ids(&storage, "stable_term");
+    assert_eq!(before_results, vec![node_id]);
+
+    migrate(&mut storage).unwrap();
+
+    let after_metadata = {
+        let txn = storage.graph_env.read_txn().unwrap();
+        let bm25 = storage.bm25.as_ref().unwrap();
+        assert_eq!(
+            bm25.schema_version(&txn).unwrap(),
+            Some(BM25_SCHEMA_VERSION)
+        );
+        bm25.metadata_db
+            .get(&txn, METADATA_KEY)
+            .unwrap()
+            .map(|bytes| bytes.to_vec())
+    };
+    let after_results = bm25_search_ids(&storage, "stable_term");
+
+    assert_eq!(after_results, vec![node_id]);
+    assert_eq!(before_results, after_results);
+    assert_eq!(before_metadata, after_metadata);
+}
+
+#[test]
+fn test_bm25_migration_repairs_stale_node_index() {
+    let (mut storage, _temp_dir) = setup_test_storage();
+    let node_id = add_test_node(&storage, "person", &[("name", Value::from("legacyalpha"))]);
+
+    assert_eq!(bm25_search_ids(&storage, "legacyalpha"), vec![node_id]);
+    assert!(bm25_search_ids(&storage, "freshomega").is_empty());
+
+    {
+        let arena = Bump::new();
+        let mut txn = storage.graph_env.write_txn().unwrap();
+        let node_bytes = storage
+            .nodes_db
+            .get(&txn, &node_id)
+            .unwrap()
+            .unwrap()
+            .to_vec();
+        let mut node = Node::from_bincode_bytes(node_id, &node_bytes, &arena).unwrap();
+        node.properties = Some(ImmutablePropertiesMap::new(
+            1,
+            std::iter::once(("name", Value::from("freshomega"))),
+            &arena,
+        ));
+
+        let updated_bytes = node.to_bincode_bytes().unwrap();
+        storage
+            .nodes_db
+            .put(&mut txn, &node_id, &updated_bytes)
+            .unwrap();
+        storage
+            .bm25
+            .as_ref()
+            .unwrap()
+            .metadata_db
+            .put(&mut txn, BM25_SCHEMA_VERSION_KEY, &0u64.to_le_bytes())
+            .unwrap();
+        txn.commit().unwrap();
+    }
+
+    assert_eq!(bm25_search_ids(&storage, "legacyalpha"), vec![node_id]);
+    assert!(bm25_search_ids(&storage, "freshomega").is_empty());
+
+    migrate(&mut storage).unwrap();
+
+    assert!(bm25_search_ids(&storage, "legacyalpha").is_empty());
+    assert_eq!(bm25_search_ids(&storage, "freshomega"), vec![node_id]);
+
+    let txn = storage.graph_env.read_txn().unwrap();
+    assert_eq!(
+        storage.bm25.as_ref().unwrap().schema_version(&txn).unwrap(),
+        Some(BM25_SCHEMA_VERSION)
+    );
+}
+
+#[test]
+fn test_bm25_migration_drops_legacy_direct_docs() {
+    let (mut storage, _temp_dir) = setup_test_storage();
+    let node_id = add_test_node(&storage, "person", &[("name", Value::from("nodeonlyterm"))]);
+
+    {
+        let mut txn = storage.graph_env.write_txn().unwrap();
+        let bm25 = storage.bm25.as_ref().unwrap();
+        bm25.insert_doc(&mut txn, 999u128, "legacyvectorterm")
+            .unwrap();
+        bm25.metadata_db
+            .put(&mut txn, BM25_SCHEMA_VERSION_KEY, &0u64.to_le_bytes())
+            .unwrap();
+        txn.commit().unwrap();
+    }
+
+    assert_eq!(bm25_search_ids(&storage, "legacyvectorterm"), vec![999u128]);
+    assert_eq!(bm25_search_ids(&storage, "nodeonlyterm"), vec![node_id]);
+
+    migrate(&mut storage).unwrap();
+
+    assert!(bm25_search_ids(&storage, "legacyvectorterm").is_empty());
+    assert_eq!(bm25_search_ids(&storage, "nodeonlyterm"), vec![node_id]);
+
+    let txn = storage.graph_env.read_txn().unwrap();
+    let metadata: BM25Metadata = bincode::deserialize(
+        storage
+            .bm25
+            .as_ref()
+            .unwrap()
+            .metadata_db
+            .get(&txn, METADATA_KEY)
+            .unwrap()
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(metadata.total_docs, 1);
 }
 
 // ============================================================================

--- a/helix-db/src/helix_engine/tests/traversal_tests/update_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/update_tests.rs
@@ -9,6 +9,7 @@ use crate::{
         storage_core::HelixGraphStorage,
         traversal_core::{
             ops::{
+                bm25::search_bm25::SearchBM25Adapter,
                 g::G,
                 source::{add_n::AddNAdapter, n_from_id::NFromIdAdapter},
                 util::update::UpdateAdapter,
@@ -89,4 +90,44 @@ fn test_update_node() {
         }
         other => panic!("unexpected traversal value: {other:?}"),
     }
+}
+
+#[test]
+fn test_update_node_without_prior_bm25_doc_becomes_searchable() {
+    let (_temp_dir, storage) = setup_test_db();
+    let arena = Bump::new();
+    let mut txn = storage.graph_env.write_txn().unwrap();
+
+    let node = G::new_mut(&storage, &arena, &mut txn)
+        .add_n("person", None, None)
+        .collect_to_obj()
+        .unwrap();
+    txn.commit().unwrap();
+
+    let arena = Bump::new();
+    let txn = storage.graph_env.read_txn().unwrap();
+    let traversal = G::new(&storage, &txn, &arena)
+        .n_from_id(&node.id())
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    drop(txn);
+
+    let arena = Bump::new();
+    let mut txn = storage.graph_env.write_txn().unwrap();
+    G::new_mut_from_iter(&storage, &mut txn, traversal.into_iter(), &arena)
+        .update(&[("name", Value::from("bm25_searchable"))])
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    txn.commit().unwrap();
+
+    let arena = Bump::new();
+    let txn = storage.graph_env.read_txn().unwrap();
+    let results = G::new(&storage, &txn, &arena)
+        .search_bm25("person", "bm25_searchable", 10)
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id(), node.id());
 }

--- a/helix-db/src/helix_engine/tests/traversal_tests/upsert_tests.rs
+++ b/helix-db/src/helix_engine/tests/traversal_tests/upsert_tests.rs
@@ -7,9 +7,11 @@ use tempfile::TempDir;
 use super::test_utils::props_option;
 use crate::{
     helix_engine::{
+        bm25::bm25::BM25,
         storage_core::HelixGraphStorage,
         traversal_core::{
             ops::{
+                bm25::search_bm25::SearchBM25Adapter,
                 g::G,
                 in_::in_::InAdapter,
                 in_::in_e::InEdgesAdapter,
@@ -701,6 +703,37 @@ fn test_upsert_e_ignores_iterator_content() {
     txn.commit().unwrap();
 }
 
+#[test]
+fn test_upsert_n_existing_node_without_prior_bm25_doc_becomes_searchable() {
+    let (_temp_dir, storage) = setup_test_db();
+    let arena = Bump::new();
+    let mut txn = storage.graph_env.write_txn().unwrap();
+
+    let existing = G::new_mut(&storage, &arena, &mut txn)
+        .add_n("person", None, None)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()[0]
+        .clone();
+    let node_id = existing.id();
+
+    G::new_mut_from_iter(&storage, &mut txn, std::iter::once(existing), &arena)
+        .upsert_n("person", &[("name", Value::from("upsert_searchable"))])
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    txn.commit().unwrap();
+
+    let arena = Bump::new();
+    let txn = storage.graph_env.read_txn().unwrap();
+    let results = G::new(&storage, &txn, &arena)
+        .search_bm25("person", "upsert_searchable", 10)
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id(), node_id);
+}
+
 // ============================================================================
 // Vector Upsert Tests (upsert_v)
 // ============================================================================
@@ -1238,12 +1271,11 @@ fn test_upsert_e_preserves_edge_relationships() {
 }
 
 #[test]
-fn test_upsert_v_with_bm25_indexing() {
+fn test_upsert_v_does_not_index_bm25() {
     let (_temp_dir, storage) = setup_test_db();
     let arena = Bump::new();
     let mut txn = storage.graph_env.write_txn().unwrap();
 
-    // Test upsert vector with text content that should be indexed by BM25
     let result = G::new_mut_from_iter(
         &storage,
         &mut txn,
@@ -1271,6 +1303,19 @@ fn test_upsert_v_with_bm25_indexing() {
     }
 
     txn.commit().unwrap();
+
+    let arena = Bump::new();
+    let txn = storage.graph_env.read_txn().unwrap();
+    let raw_results = storage
+        .bm25
+        .as_ref()
+        .unwrap()
+        .search(&txn, "machine learning", 10, &arena)
+        .unwrap();
+    assert!(
+        raw_results.is_empty(),
+        "vector upsert should not affect BM25"
+    );
 }
 
 #[test]

--- a/helix-db/src/helix_engine/traversal_core/ops/source/add_n.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/source/add_n.rs
@@ -1,6 +1,6 @@
 use crate::{
     helix_engine::{
-        bm25::bm25::{BM25, BM25Flatten},
+        bm25::bm25::{BM25, build_bm25_payload},
         storage_core::HelixGraphStorage,
         traversal_core::{traversal_iter::RwTraversalIterator, traversal_value::TraversalValue},
         types::GraphError,
@@ -141,8 +141,7 @@ impl<'db, 'arena, 'txn, 's, I: Iterator<Item = Result<TraversalValue<'arena>, Gr
         if let Some(bm25) = &self.storage.bm25
             && let Some(props) = node.properties.as_ref()
         {
-            let mut data = props.flatten_bm25();
-            data.push_str(node.label);
+            let data = build_bm25_payload(props, node.label);
             if let Err(e) = bm25.insert_doc(self.txn, node.id, &data) {
                 result = Err(e);
             }

--- a/helix-db/src/helix_engine/traversal_core/ops/util/update.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/util/update.rs
@@ -3,6 +3,7 @@ use itertools::Itertools;
 
 use crate::{
     helix_engine::{
+        bm25::bm25::{BM25, build_bm25_payload},
         traversal_core::{traversal_iter::RwTraversalIterator, traversal_value::TraversalValue},
         types::GraphError,
     },
@@ -174,6 +175,16 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
                                 );
 
                                 node.properties = Some(new_map);
+                            }
+                        }
+
+                        if let Some(bm25) = &self.storage.bm25
+                            && let Some(properties) = node.properties.as_ref()
+                        {
+                            let data = build_bm25_payload(properties, node.label);
+                            if let Err(e) = bm25.update_doc(self.txn, node.id, &data) {
+                                results.push(Err(e));
+                                continue;
                             }
                         }
 

--- a/helix-db/src/helix_engine/traversal_core/ops/util/upsert.rs
+++ b/helix-db/src/helix_engine/traversal_core/ops/util/upsert.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 
 use crate::{
     helix_engine::{
-        bm25::bm25::{BM25, BM25Flatten},
+        bm25::bm25::{BM25, build_bm25_payload},
         storage_core::{HelixGraphStorage, storage_methods::StorageMethods},
         traversal_core::{traversal_iter::RwTraversalIterator, traversal_value::TraversalValue},
         types::GraphError,
@@ -281,8 +281,7 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
                     if let Some(bm25) = &self.storage.bm25
                         && let Some(props) = node.properties.as_ref()
                     {
-                        let mut data = props.flatten_bm25();
-                        data.push_str(node.label);
+                        let data = build_bm25_payload(props, node.label);
                         bm25.update_doc(self.txn, node.id, &data)?;
                     }
 
@@ -352,8 +351,7 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
                     if let Some(bm25) = &self.storage.bm25
                         && let Some(props) = node.properties.as_ref()
                     {
-                        let mut data = props.flatten_bm25();
-                        data.push_str(node.label);
+                        let data = build_bm25_payload(props, node.label);
                         bm25.insert_doc(self.txn, node.id, &data)?;
                     }
 
@@ -694,15 +692,6 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
                         }
                     }
 
-                    // Update BM25 index for existing vector
-                    if let Some(bm25) = &self.storage.bm25
-                        && let Some(props) = vector.properties.as_ref()
-                    {
-                        let mut data = props.flatten_bm25();
-                        data.push_str(vector.label);
-                        bm25.update_doc(self.txn, vector.id, &data)?;
-                    }
-
                     self.storage.vectors.put_vector(self.txn, &vector)?;
                     Ok(TraversalValue::Vector(vector))
                 }
@@ -753,14 +742,6 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
                                 )?,
                             crate::helix_engine::types::SecondaryIndex::None => unreachable!(),
                         }
-                    }
-
-                    if let Some(bm25) = &self.storage.bm25
-                        && let Some(props) = vector.properties.as_ref()
-                    {
-                        let mut data = props.flatten_bm25();
-                        data.push_str(vector.label);
-                        bm25.insert_doc(self.txn, vector.id, &data)?;
                     }
 
                     Ok(TraversalValue::Vector(vector))
@@ -904,15 +885,6 @@ impl<'db, 'arena, 'txn, I: Iterator<Item = Result<TraversalValue<'arena>, GraphE
 
                             vector.properties = Some(new_map);
                         }
-                    }
-
-                    // Update BM25 index for existing vector
-                    if let Some(bm25) = &self.storage.bm25
-                        && let Some(props) = vector.properties.as_ref()
-                    {
-                        let mut data = props.flatten_bm25();
-                        data.push_str(vector.label);
-                        bm25.update_doc(self.txn, vector.id, &data)?;
                     }
 
                     self.storage.vectors.put_vector(self.txn, &vector)?;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the BM25 full-text search subsystem by introducing a **reverse index** (`doc_id → list of (term, tf)`) alongside the existing inverted index, enabling correct and efficient delete/update operations without re-scanning the inverted index. It also adds **schema versioning** so that on startup, if the stored index was built without the reverse index, the migration layer automatically clears and rebuilds the entire BM25 index from `nodes_db`. The `add_n`, `update`, and `upsert` traversal operators are updated to maintain BM25 invariants as nodes are created or changed.

Key changes:
- **`bm25.rs`**: Adds `ReversePostingEntry`, `DocPresence`/`DocState` enums, `reverse_index_db` (DUP_SORT), schema version read/write, and refactored `insert_doc` / `delete_doc` / `update_doc` that enforce strict consistency invariants (returns errors on index corruption).
- **`storage_migration.rs`**: `migrate_bm25` clears and rebuilds the BM25 index in 1 024-node batches when the stored schema version doesn't match `BM25_SCHEMA_VERSION = 2`.
- **`add_n.rs`**: `bm25.insert_doc` is called after writing the node — but without a guard that checks whether the `nodes_db` write succeeded, allowing BM25 errors to mask prior errors.
- **`update.rs` / `upsert.rs`**: BM25 is correctly updated before (update) or after (upsert new node) the `nodes_db` write, with proper error propagation.
- Comprehensive new tests cover the reverse index, schema migration, update-to-searchable, and invariant enforcement.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| helix-db/src/helix_engine/bm25/bm25.rs | Core BM25 rewrite adding a reverse index (doc_id → terms) and schema versioning. Logic is sound overall; minor duplication between reverse_entries and reverse_entries_rw. |
| helix-db/src/helix_engine/traversal_core/ops/source/add_n.rs | BM25 insert_doc is called unconditionally after nodes_db write, even on prior failure — can mask the original error if BM25 also fails. |
| helix-db/src/helix_engine/storage_core/storage_migration.rs | Adds migrate_bm25 that clears and rebuilds the BM25 index from nodes_db. Holding read_txn alive across batch write transactions can cause LMDB freelist growth; nodes without properties are silently skipped (consistent with add_n but deserves a comment). |
| helix-db/src/helix_engine/traversal_core/ops/util/update.rs | Correctly calls bm25.update_doc before nodes_db write; BM25 error short-circuits the node save, and both are in the same transaction so rollback is safe. |
| helix-db/src/helix_engine/traversal_core/ops/util/upsert.rs | BM25 insert_doc (new node) and update_doc (existing node) are correctly integrated into upsert_n; error propagation follows the existing ? pattern. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant migrate_bm25
    participant BM25Index
    participant nodes_db
    participant add_n / update / upsert

    Note over Caller, BM25Index: Startup Migration Path
    Caller->>migrate_bm25: migrate(storage)
    migrate_bm25->>BM25Index: schema_version(read_txn)
    alt version matches BM25_SCHEMA_VERSION
        BM25Index-->>migrate_bm25: Some(2) — skip
    else outdated or missing
        migrate_bm25->>BM25Index: clear_all(write_txn)
        migrate_bm25->>nodes_db: iter(read_txn) — batch by 1024
        loop Each batch
            migrate_bm25->>BM25Index: insert_doc per node with properties (write_txn)
        end
        migrate_bm25->>BM25Index: write_schema_version(2, write_txn)
    end

    Note over Caller, BM25Index: Normal Write Path
    Caller->>add_n / update / upsert: write op (RwTxn)
    add_n / update / upsert->>nodes_db: put node
    add_n / update / upsert->>BM25Index: insert_doc / update_doc / delete_doc
    BM25Index->>BM25Index: update inverted_index_db (term→postings)
    BM25Index->>BM25Index: update reverse_index_db (doc_id→terms)
    BM25Index->>BM25Index: update doc_lengths_db
    BM25Index->>BM25Index: update term_frequencies_db
    BM25Index->>BM25Index: update metadata (total_docs, avgdl)
    add_n / update / upsert-->>Caller: Result<TraversalValue>
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `helix-db/src/helix_engine/traversal_core/ops/source/add_n.rs`, line 141-148 ([link](https://github.com/helixdb/helix-db/blob/8d28406c1ec70c56ba3100205080a9bb7a9ea17c/helix-db/src/helix_engine/traversal_core/ops/source/add_n.rs#L141-L148)) 

   **BM25 insert runs unconditionally, can mask prior errors**

   The BM25 `insert_doc` call (lines 141-148) runs even when a previous operation failed (secondary-index insertion or `nodes_db.put_with_flags`). If `bm25.insert_doc` then also fails, it silently overwrites the original error stored in `result`, making the caller receive a BM25 error instead of the real `nodes_db` or secondary-index error. Adding an early-exit guard fixes both the error masking and the wasted BM25 work:

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 8d28406</sub>

<!-- /greptile_comment -->